### PR TITLE
Add width/height/srcset to Insights images

### DIFF
--- a/insights/2024/payment-networks-explained/index.html
+++ b/insights/2024/payment-networks-explained/index.html
@@ -449,8 +449,10 @@
             <h2 class="section-title">Payment Network Architecture</h2>
             <div class="infrastructure-diagram">
                 <div style="text-align: center;">
-                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif" 
-                         alt="Payment Network Architecture Flow" 
+                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif"
+                         srcset="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 600w, https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 1200w"
+                         width="1200" height="675" loading="lazy"
+                         alt="Payment Network Architecture Flow"
                          style="max-width: 100%; height: auto; border-radius: 12px; box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15);">
                 </div>
                 <p style="text-align: center; margin-top: 2rem; color: #7e7e7e; font-style: italic;">Direct access to payment networks can be costly. Financial service providers (Gateways) facilitate access by allowing businesses to connect through their infrastructure.</p>
@@ -467,8 +469,10 @@
             
             <!-- Network Categories Visual -->
             <div style="text-align: center; margin: 3rem 0;">
-                <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png" 
-                     alt="Payment Network Categories - Digital, Peer-to-Peer, and Card Networks" 
+                <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png"
+                     srcset="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png 600w, https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png 1200w"
+                     width="1200" height="675" loading="lazy"
+                     alt="Payment Network Categories - Digital, Peer-to-Peer, and Card Networks"
                      style="max-width: 100%; height: auto; border-radius: 16px; box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15); border: 2px solid rgba(199, 125, 255, 0.2);">
             </div>
             

--- a/insights/2024/pre-treasury-explained/index.html
+++ b/insights/2024/pre-treasury-explained/index.html
@@ -370,7 +370,10 @@
                         <a href="#contact" class="cta-button">Request a Free Assessment</a>
                     </div>
                     <div class="hero-image fade-in">
-                        <img src="https://images.unsplash.com/photo-1634952504883-53a6b482a7a4?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=1200" alt="Modern financial dashboard analytics">
+                        <img src="https://images.unsplash.com/photo-1634952504883-53a6b482a7a4?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=1200"
+                             srcset="https://images.unsplash.com/photo-1634952504883-53a6b482a7a4?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=600 600w, https://images.unsplash.com/photo-1634952504883-53a6b482a7a4?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=1200 1200w"
+                             width="1200" height="800" loading="lazy"
+                             alt="Modern financial dashboard analytics">
                     </div>
                 </div>
             </div>
@@ -453,7 +456,10 @@
             <div class="container">
                 <div class="playbook-wrapper">
                     <div class="playbook-image fade-in">
-                        <img src="https://images.unsplash.com/photo-1542744095-291d1f67b221?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=1200" alt="Team collaborating around a table with documents">
+                        <img src="https://images.unsplash.com/photo-1542744095-291d1f67b221?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=1200"
+                             srcset="https://images.unsplash.com/photo-1542744095-291d1f67b221?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=600 600w, https://images.unsplash.com/photo-1542744095-291d1f67b221?ixlib=rb-4.0.3&q=85&fm=jpg&crop=entropy&cs=srgb&w=1200 1200w"
+                             width="1200" height="800" loading="lazy"
+                             alt="Team collaborating around a table with documents">
                     </div>
                     <div class="playbook-text fade-in">
                         <h2>Download The Pre-Treasury Playbook</h2>

--- a/insights/2025/tms-selection-guide/index.html
+++ b/insights/2025/tms-selection-guide/index.html
@@ -374,10 +374,11 @@
     <!-- Treasury Data Flow Image -->
     <section class="section section-alt">
         <div class="container" style="text-align: center;">
-            <img src="https://lirp.cdn-website.com/b5a55ad0/dms3rep/multi/opt/Treasury+Data+Flow-c6cdb042-1920w.png" 
-                 alt="Treasury Management System Data Flow Diagram showing information flow between departments" 
-                 class="content-image"
-                 loading="lazy">
+            <img src="https://lirp.cdn-website.com/b5a55ad0/dms3rep/multi/opt/Treasury+Data+Flow-c6cdb042-1920w.png"
+                 srcset="https://lirp.cdn-website.com/b5a55ad0/dms3rep/multi/opt/Treasury+Data+Flow-c6cdb042-960w.png 960w, https://lirp.cdn-website.com/b5a55ad0/dms3rep/multi/opt/Treasury+Data+Flow-c6cdb042-1920w.png 1920w"
+                 width="1920" height="1080" loading="lazy"
+                 alt="Treasury Management System Data Flow Diagram showing information flow between departments"
+                 class="content-image">
         </div>
     </section>
 

--- a/insights/index.html
+++ b/insights/index.html
@@ -505,7 +505,12 @@
                 };
 
                 posts.forEach((post, index) => {
-                    const imageUrl = post._embedded?.['wp:featuredmedia']?.[0]?.source_url || `https://placehold.co/600x400/7216f4/FFFFFF?text=${post.title.rendered.split(' ')[0]}`;
+                    const featuredMedia = post._embedded?.['wp:featuredmedia']?.[0];
+                    const imageUrl = featuredMedia?.source_url || `https://placehold.co/600x400/7216f4/FFFFFF?text=${post.title.rendered.split(' ')[0]}`;
+                    const sizes = featuredMedia?.media_details?.sizes;
+                    const srcset = sizes ? Object.values(sizes).map(size => `${size.source_url} ${size.width}w`).join(', ') : '';
+                    const width = featuredMedia?.media_details?.width || 600;
+                    const height = featuredMedia?.media_details?.height || 400;
                     const category = post._embedded?.['wp:term']?.[0]?.[0]?.name || 'Uncategorized';
                     const excerpt = post.excerpt.rendered.replace(/<[^>]+>/g, '').substring(0, 120) + '...';
 
@@ -513,7 +518,7 @@
                     card.className = 'insight-card';
                     card.style.animationDelay = `${index * 100}ms`;
                     card.innerHTML = `
-                        <img src="${imageUrl}" alt="${post.title.rendered}" class="card-image">
+                        <img src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" loading="lazy" alt="${post.title.rendered}" class="card-image">
                         <div class="card-content">
                             <span class="card-category">${category}</span>
                             <h2 class="card-title">${post.title.rendered}</h2>


### PR DESCRIPTION
## Summary
- add lazy loading, width/height, and srcset attributes for inline images
- populate responsive image data for Insights grid

## Testing
- `tidy -qe insights/2024/pre-treasury-explained/index.html`
- `tidy -qe insights/2024/payment-networks-explained/index.html`
- `tidy -qe insights/2025/tms-selection-guide/index.html`
- `tidy -qe insights/index.html`


------
https://chatgpt.com/codex/tasks/task_e_686408195630833184c71e029dc475a7