### PR TITLE
Improve alt text descriptions

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -441,7 +441,7 @@
                 <div class="text-center">
                     <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600">
                         <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg"
-                             alt="Tim - Co-Founder"
+                             alt="ERR NOT Method page headshot of Tim Schultz, Co-Founder"
                              class="w-full h-full object-cover">
                     </div>
                     <h3 class="text-2xl font-bold mb-2">Tim</h3>
@@ -459,7 +459,7 @@
                 <div class="text-center">
                     <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600">
                         <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png"
-                             alt="Tracey - Co-Founder"
+                             alt="ERR NOT Method page headshot of Tracey Knight, Co-Founder"
                              class="w-full h-full object-cover">
                     </div>
                     <h3 class="text-2xl font-bold mb-2">Tracey</h3>

--- a/index.html
+++ b/index.html
@@ -1198,7 +1198,7 @@
                 <div class="team-card">
                     <div class="team-image">
                         <div class="image-editor">
-                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Tim - Co-Founder">
+                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Homepage headshot of Tim Schultz, Co-Founder">
                         </div>
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL Consultant</div>
@@ -1235,7 +1235,7 @@
                 <div class="team-card">
                     <div class="team-image">
                         <div class="image-editor">
-                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Tracey - Co-Founder">
+                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Homepage headshot of Tracey Knight, Co-Founder">
                         </div>
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL CONSULTANT</div>

--- a/insights/index.html
+++ b/insights/index.html
@@ -519,7 +519,7 @@
                     card.className = 'insight-card';
                     card.style.animationDelay = `${index * 100}ms`;
                     card.innerHTML = `
-                        <img src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" loading="lazy" alt="${post.title.rendered}" class="card-image">
+                        <img src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" loading="lazy" alt="Blog header for ${post.title.rendered}" class="card-image">
                         <div class="card-content">
                             <span class="card-category">${category}</span>
                             <h2 class="card-title">${post.title.rendered}</h2>

--- a/team/index.html
+++ b/team/index.html
@@ -730,7 +730,7 @@
                 <!-- Tim's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Tim - Co-Founder">
+                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Team page headshot of Tim Schultz, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL Consultant</div>
                     <h3 class="team-name">Tim</h3>
@@ -765,7 +765,7 @@
                 <!-- Tracey's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Tracey - Co-Founder">
+                            <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Team page headshot of Tracey Knight, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL CONSULTANT</div>
                     <h3 class="team-name">Tracey</h3>

--- a/treasury-tech-stack/index.html
+++ b/treasury-tech-stack/index.html
@@ -1924,7 +1924,7 @@
                     </div>
                 </div>
                 <div class="modal-body">
-                    <img id="modalToolLogo" class="modal-tool-logo" alt="">
+                    <img id="modalToolLogo" class="modal-tool-logo" alt="Selected tool logo">
                     <!-- The Overview is now static in the HTML structure -->
                     <div class="feature-section">
                         <h4>🎯 Overview</h4>


### PR DESCRIPTION
## Summary
- add page-specific alt text for team member headshots
- use descriptive alt for insights listing images
- include placeholder alt for modal logos

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68640d1295448331a74e61c8bc3b6fa5