### PR TITLE
Fix stray PHP tag in functions.php

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1408,8 +1408,6 @@ function add_custom_related_posts() {
     }
 }
 add_action('wp', 'add_custom_related_posts');
-
-<?php
 // Remove default Astra post footer elements
 function remove_astra_post_footer_elements() {
     if (is_single()) {


### PR DESCRIPTION
## Summary
- remove stray `<?php` line that caused syntax error in `functions.php`

## Testing
- `npm install`
- `npm run build`
- `php -l assets/php/functions.php` *(fails: Cannot redeclare add_custom_related_posts())*

------
https://chatgpt.com/codex/tasks/task_e_686410d810a4833184ab98c7f686bfb5