### PR TITLE
Refactor related posts layout

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1905,179 +1905,34 @@ p {
     color: #333 !important;
     transform: scale(1.1) !important;
 }
-/* Custom Related Posts Styling */
-.custom-related-posts-wrapper {
+/* Related Posts Slider */
+.rt-related-posts {
     margin-top: 3rem;
     padding-top: 2rem;
     border-top: 2px solid #f1f1f1;
 }
 
-.custom-related-posts {
-    max-width: 100%;
-}
-
-.related-posts-title {
-    font-size: 1.8rem;
-    font-weight: 600;
-    margin-bottom: 2rem;
-    color: #333;
+.rt-related-heading {
+    font-size: 1.6rem;
     text-align: center;
-    position: relative;
+    margin-bottom: 1.5rem;
 }
 
-.related-posts-title::after {
-    content: '';
-    position: absolute;
-    bottom: -10px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 50px;
-    height: 3px;
-    background: #0073aa;
+.rt-related-container {
+    display: flex;
+    gap: 1rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    padding-bottom: 1rem;
 }
 
-.related-posts-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-    margin-bottom: 2rem;
+.rt-related-item {
+    flex: 0 0 250px;
+    scroll-snap-align: start;
 }
 
-.related-post-item {
-    background: #fff;
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
-    border: 1px solid #eee;
-}
-
-.related-post-item:hover {
-    transform: translateY(-8px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
-}
-
-.related-post-thumbnail {
-    position: relative;
-    overflow: hidden;
-    height: 200px;
-}
-
-.related-post-img {
+.rt-related-thumb {
     width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 0.3s ease;
-}
-
-.related-post-item:hover .related-post-img {
-    transform: scale(1.1);
-}
-
-.related-post-content {
-    padding: 1.5rem;
-}
-
-.related-post-title {
-    font-size: 1.2rem;
-    font-weight: 600;
-    margin: 0 0 0.5rem 0;
-    line-height: 1.4;
-}
-
-.related-post-title a {
-    color: #333;
-    text-decoration: none;
-    transition: color 0.3s ease;
-}
-
-.related-post-title a:hover {
-    color: #0073aa;
-}
-
-.related-post-meta {
-    margin-bottom: 1rem;
-}
-
-.related-post-date {
-    font-size: 0.9rem;
-    color: #666;
-}
-
-.related-post-excerpt {
-    color: #555;
-    line-height: 1.6;
-    margin-bottom: 1rem;
-    font-size: 0.95rem;
-}
-
-.related-post-link {
-    color: #0073aa;
-    text-decoration: none;
-    font-weight: 600;
-    font-size: 0.9rem;
-    transition: all 0.3s ease;
-    display: inline-block;
-}
-
-.related-post-link:hover {
-    color: #005a87;
-    transform: translateX(5px);
-}
-
-/* Mobile Responsiveness */
-@media (max-width: 768px) {
-    .related-posts-grid {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-    }
-    
-    .related-posts-title {
-        font-size: 1.5rem;
-    }
-    
-    .related-post-content {
-        padding: 1.2rem;
-    }
-    
-    .related-post-thumbnail {
-        height: 180px;
-    }
-}
-
-@media (max-width: 480px) {
-    .custom-related-posts-wrapper {
-        margin-top: 2rem;
-        padding-top: 1.5rem;
-    }
-    
-    .related-post-content {
-        padding: 1rem;
-    }
-}
-
-/* Integration with Astra theme colors */
-body.ast-desktop .custom-related-posts-wrapper {
-    background: inherit;
-}
-
-/* Dark mode support if your theme has it */
-@media (prefers-color-scheme: dark) {
-    .related-post-item {
-        background: #1a1a1a;
-        border-color: #333;
-    }
-    
-    .related-posts-title,
-    .related-post-title a {
-        color: #fff;
-    }
-    
-    .related-post-excerpt {
-        color: #ccc;
-    }
-    
-    .related-post-date {
-        color: #999;
-    }
+    border-radius: 4px;
+    display: block;
 }

--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1359,81 +1359,62 @@ function remove_astra_post_footer_elements() {
 }
 add_action('wp', 'remove_astra_post_footer_elements');
 
-// Custom Related Posts Function
-function custom_related_posts_section() {
-    if (!is_single()) return;
-    
+/**
+ * Display related posts after the single post content.
+ * Uses a simple slider layout with horizontal scrolling.
+ */
+function display_related_posts() {
+    if ( ! is_single() ) {
+        return;
+    }
+
     global $post;
-    
-    // Get current post categories
-    $categories = get_the_category($post->ID);
-    if (empty($categories)) return;
-    
-    $category_ids = wp_list_pluck($categories, 'term_id');
-    
-    // Query for related posts
-    $related_posts = new WP_Query(array(
-        'post_type' => 'post',
-        'posts_per_page' => 3,
-        'post__not_in' => array($post->ID),
-        'category__in' => $category_ids,
-        'orderby' => 'rand',
-        'meta_query' => array(
-            array(
-                'key' => '_thumbnail_id',
-                'compare' => 'EXISTS'
+
+    $categories = get_the_category( $post->ID );
+    if ( empty( $categories ) ) {
+        return;
+    }
+
+    $category_ids = wp_list_pluck( $categories, 'term_id' );
+
+    $related = new WP_Query(
+        array(
+            'post_type'      => 'post',
+            'posts_per_page' => 6,
+            'post__not_in'   => array( $post->ID ),
+            'category__in'   => $category_ids,
+            'orderby'        => 'rand',
+            'meta_query'     => array(
+                array(
+                    'key'     => '_thumbnail_id',
+                    'compare' => 'EXISTS',
+                ),
             ),
-        ),
-    ));
-    
-    if ($related_posts->have_posts()) : ?>
-        <div class="custom-related-posts-wrapper">
-            <div class="custom-related-posts">
-                <h3 class="related-posts-title">Related Posts</h3>
-                <div class="related-posts-grid">
-                    <?php while ($related_posts->have_posts()) : $related_posts->the_post(); ?>
-                        <article class="related-post-item">
-                            <?php if (has_post_thumbnail()) : ?>
-                                <div class="related-post-thumbnail">
-                                    <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
-                                        <?php the_post_thumbnail('medium', array('class' => 'related-post-img')); ?>
-                                    </a>
-                                </div>
-                            <?php endif; ?>
-                            
-                            <div class="related-post-content">
-                                <h4 class="related-post-title">
-                                    <a href="<?php the_permalink(); ?>" title="<?php the_title_attribute(); ?>">
-                                        <?php the_title(); ?>
-                                    </a>
-                                </h4>
-                                
-                                <div class="related-post-meta">
-                                    <span class="related-post-date"><?php echo get_the_date(); ?></span>
-                                </div>
-                                
-                                <div class="related-post-excerpt">
-                                    <?php echo wp_trim_words(get_the_excerpt(), 20, '...'); ?>
-                                </div>
-                                
-                                <a href="<?php the_permalink(); ?>" class="related-post-link">Read More →</a>
-                            </div>
-                        </article>
-                    <?php endwhile; ?>
-                </div>
-            </div>
-        </div>
-    <?php 
-    endif;
-    
+        )
+    );
+
+    if ( $related->have_posts() ) {
+        echo '<aside class="rt-related-posts">';
+        echo '<h3 class="rt-related-heading">Related Posts</h3>';
+        echo '<div class="rt-related-container">';
+
+        while ( $related->have_posts() ) {
+            $related->the_post();
+            echo '<article class="rt-related-item">';
+            if ( has_post_thumbnail() ) {
+                echo '<a href="' . esc_url( get_permalink() ) . '" class="rt-related-thumb-link">';
+                the_post_thumbnail( 'medium', array( 'class' => 'rt-related-thumb' ) );
+                echo '</a>';
+            }
+            echo '<h4 class="rt-related-title"><a href="' . esc_url( get_permalink() ) . '">' . get_the_title() . '</a></h4>';
+            echo '</article>';
+        }
+
+        echo '</div></aside>';
+    }
+
     wp_reset_postdata();
 }
 
-// Add custom related posts to the post footer area
-function add_custom_related_posts() {
-    if (is_single()) {
-        add_action('astra_entry_after', 'custom_related_posts_section', 25);
-    }
-}
-add_action('wp', 'add_custom_related_posts');
+add_action( 'astra_entry_after', 'display_related_posts', 25 );
 ?>


### PR DESCRIPTION
## Summary
- remove old custom related posts logic
- implement `display_related_posts` with streamlined slider layout
- drop large related posts CSS block and add minimal slider styles

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_68641a95cebc8331a83688b77b11d1de