### PR TITLE
Fix related posts output and load shared CSS

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1416,5 +1416,18 @@ function display_related_posts() {
     wp_reset_postdata();
 }
 
-// add_action( 'astra_entry_after', 'display_related_posts', 25 );
+add_action( 'astra_entry_after', 'display_related_posts', 25 );
+
+/**
+ * Enqueue shared stylesheet used by insight pages and related posts markup.
+ */
+function rt_enqueue_shared_styles() {
+    wp_enqueue_style(
+        'rt-shared-styles',
+        get_template_directory_uri() . '/assets/css/shared.css',
+        array(),
+        '1.0'
+    );
+}
+add_action( 'wp_enqueue_scripts', 'rt_enqueue_shared_styles' );
 ?>


### PR DESCRIPTION
## Summary
- hook custom `display_related_posts` into Astra
- enqueue `shared.css` so copied insight markup is styled

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864380347288331a3c3151092f9d2b6