### PR TITLE
Remove shared.css links from EJS templates

### DIFF
--- a/insights/2024/cash-tools-explained/index.html
+++ b/insights/2024/cash-tools-explained/index.html
@@ -16,7 +16,6 @@
     <link rel="canonical" href="https://www.realtreasury.com/cash-tools-explained">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* Import the existing glassmorphism styles */
         :root {

--- a/insights/2024/cloud-services-today/index.html
+++ b/insights/2024/cloud-services-today/index.html
@@ -38,7 +38,6 @@
     
     <title>Treasury Marketplace Part 1: Infrastructure Revolution in Corporate Finance | Real Treasury</title>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/insights/2024/cre-treasury-tech/index.html
+++ b/insights/2024/cre-treasury-tech/index.html
@@ -64,7 +64,6 @@
     
     <title>Treasury Technology for Real Estate Funds: Complete Guide | Real Treasury</title>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/insights/2024/payment-networks-explained/index.html
+++ b/insights/2024/payment-networks-explained/index.html
@@ -13,7 +13,6 @@
     <meta property="og:url" content="https://www.realtreasury.com/payment-networks-explained">
     <link rel="canonical" href="https://www.realtreasury.com/payment-networks-explained">
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* Include the glassmorphism CSS styles */
         :root {

--- a/insights/2024/pre-treasury-explained/index.html
+++ b/insights/2024/pre-treasury-explained/index.html
@@ -19,7 +19,6 @@
     <!-- Phosphor Icons -->
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
 
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* ===============================================================
          * Root Variables & Base Styles

--- a/insights/2024/real-estate-ownership-explained/index.html
+++ b/insights/2024/real-estate-ownership-explained/index.html
@@ -35,7 +35,6 @@
     }
     </script>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/insights/2024/real-treasury-explained/index.html
+++ b/insights/2024/real-treasury-explained/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Discover how Real Treasury's cutting-edge platform transforms treasury management. See why 500+ finance leaders choose our AI-powered solutions for cash optimization.">
     
     <!-- Your existing CSS would be linked here -->
-    <link rel="stylesheet" href="/assets/css/shared.css">
     
     <style>
         * {

--- a/insights/2024/tms-data-flow/index.html
+++ b/insights/2024/tms-data-flow/index.html
@@ -90,7 +90,6 @@
     }
     </script>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* CSS Variables for Consistent Design */
         :root {

--- a/insights/2025/tms-selection-guide/index.html
+++ b/insights/2025/tms-selection-guide/index.html
@@ -46,7 +46,6 @@
     </script>
     
     <!-- CSS Framework and Custom Styles -->
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* Import your existing CSS here - I'll include key styles inline for the artifact */
         

--- a/insights/index.html
+++ b/insights/index.html
@@ -25,7 +25,6 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/templates/insights/2024/cash-tools-explained/index.html
+++ b/templates/insights/2024/cash-tools-explained/index.html
@@ -16,7 +16,6 @@
     <link rel="canonical" href="https://www.realtreasury.com/cash-tools-explained">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* Import the existing glassmorphism styles */
         :root {

--- a/templates/insights/2024/cloud-services-today/index.html
+++ b/templates/insights/2024/cloud-services-today/index.html
@@ -38,7 +38,6 @@
     
     <title>Treasury Marketplace Part 1: Infrastructure Revolution in Corporate Finance | Real Treasury</title>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/templates/insights/2024/cre-treasury-tech/index.html
+++ b/templates/insights/2024/cre-treasury-tech/index.html
@@ -64,7 +64,6 @@
     
     <title>Treasury Technology for Real Estate Funds: Complete Guide | Real Treasury</title>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/templates/insights/2024/payment-networks-explained/index.html
+++ b/templates/insights/2024/payment-networks-explained/index.html
@@ -13,7 +13,6 @@
     <meta property="og:url" content="https://www.realtreasury.com/payment-networks-explained">
     <link rel="canonical" href="https://www.realtreasury.com/payment-networks-explained">
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* Include the glassmorphism CSS styles */
         :root {

--- a/templates/insights/2024/pre-treasury-explained/index.html
+++ b/templates/insights/2024/pre-treasury-explained/index.html
@@ -19,7 +19,6 @@
     <!-- Phosphor Icons -->
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
 
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* ===============================================================
          * Root Variables & Base Styles

--- a/templates/insights/2024/real-estate-ownership-explained/index.html
+++ b/templates/insights/2024/real-estate-ownership-explained/index.html
@@ -35,7 +35,6 @@
     }
     </script>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;

--- a/templates/insights/2024/real-treasury-explained/index.html
+++ b/templates/insights/2024/real-treasury-explained/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Discover how Real Treasury's cutting-edge platform transforms treasury management. See why 500+ finance leaders choose our AI-powered solutions for cash optimization.">
     
     <!-- Your existing CSS would be linked here -->
-    <link rel="stylesheet" href="/assets/css/shared.css">
     
     <style>
         * {

--- a/templates/insights/2024/tms-data-flow/index.html
+++ b/templates/insights/2024/tms-data-flow/index.html
@@ -90,7 +90,6 @@
     }
     </script>
     
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* CSS Variables for Consistent Design */
         :root {

--- a/templates/insights/2025/tms-selection-guide/index.html
+++ b/templates/insights/2025/tms-selection-guide/index.html
@@ -46,7 +46,6 @@
     </script>
     
     <!-- CSS Framework and Custom Styles -->
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         /* Import your existing CSS here - I'll include key styles inline for the artifact */
         

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -25,7 +25,6 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="/assets/css/shared.css">
     <style>
         :root {
             --primary-purple: #7216f4;


### PR DESCRIPTION
## Summary
- remove `<link rel="stylesheet" href="/assets/css/shared.css">` from insight templates
- rebuild generated HTML

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68644919e3988331bdfa51ea06100155