### PR TITLE
Remove shared style enqueue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ npm run build
 ```
 
 The `build` script renders every template in `templates/` and writes the resulting HTML files back into the repository structure.
+
+## WordPress Additional CSS
+
+The WordPress theme previously enqueued `assets/css/shared.css`. After removing
+that function, copy the contents of `assets/css/shared.css` into the
+WordPress **Additional CSS** area (Appearance → Customize → Additional CSS) to
+retain the same styling.

--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1426,16 +1426,4 @@ function display_related_posts() {
 // Hook it to display after post content
 add_action( 'astra_entry_after', 'display_related_posts', 25 );
 
-/**
- * Enqueue shared stylesheet used by insight pages and related posts markup.
- */
-function rt_enqueue_shared_styles() {
-    wp_enqueue_style(
-        'rt-shared-styles',
-        get_template_directory_uri() . '/assets/css/shared.css',
-        array(),
-        '1.0'
-    );
-}
-add_action( 'wp_enqueue_scripts', 'rt_enqueue_shared_styles' );
 ?>


### PR DESCRIPTION
## Summary
- delete `rt_enqueue_shared_styles` from functions.php
- mention using the file contents in WordPress Additional CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68644934844083318ad18290714eb178