### PR TITLE
Update README for manual shared CSS copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ The `build` script renders every template in `templates/` and writes the resulti
 
 ## WordPress Additional CSS
 
-The WordPress theme previously enqueued `assets/css/shared.css`. After removing
-that function, copy the contents of `assets/css/shared.css` into the
-WordPress **Additional CSS** area (Appearance → Customize → Additional CSS) to
-retain the same styling.
+The file `assets/css/shared.css` is version controlled in this repository but is
+no longer loaded automatically by the theme. To keep these shared styles active,
+manually copy the file contents into WordPress:
+
+1. Open `assets/css/shared.css` and copy all of its text.
+2. In the WordPress admin go to **Appearance → Customize → Additional CSS**.
+3. Paste the CSS into the editor and click **Publish**.
+
+Repeat these steps whenever `shared.css` changes in Git.


### PR DESCRIPTION
## Summary
- clarify that `assets/css/shared.css` is tracked in git but must be copied manually
- provide numbered instructions for copying into WordPress

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68644d34a34c8331b0e1353518b020e3