### PR TITLE
Append related posts via the_content filter

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1333,16 +1333,16 @@ function add_bank_report_javascript() {
  * Display glassmorphism-styled related posts at end of post content
  */
 function display_custom_related_posts() {
-    // Only show on single posts
+    // Only build markup for single posts
     if ( ! is_single() ) {
-        return;
+        return '';
     }
 
     global $post;
 
     $categories = get_the_category( $post->ID );
     if ( empty( $categories ) ) {
-        return;
+        return '';
     }
 
     $category_ids = wp_list_pluck( $categories, 'term_id' );
@@ -1363,39 +1363,56 @@ function display_custom_related_posts() {
         )
     );
 
+    $output = '';
+
     if ( $related->have_posts() ) {
-        echo '<div class="related-posts-wrapper" style="background: linear-gradient(135deg, #f8f8f8 0%, #ffffff 50%, #f0f0f0 100%); padding: 4rem 0; margin-top: 3rem;">';
-        echo '<div class="ast-container" style="max-width: 1200px; margin: 0 auto; padding: 0 20px;">';
-        echo '<section class="custom-related-posts">';
-        echo '<h2 class="related-posts-title">Related Posts</h2>';
-        echo '<div class="related-posts-grid">';
+        $output .= '<div class="related-posts-wrapper" style="background: linear-gradient(135deg, #f8f8f8 0%, #ffffff 50%, #f0f0f0 100%); padding: 4rem 0; margin-top: 3rem;">';
+        $output .= '<div class="ast-container" style="max-width: 1200px; margin: 0 auto; padding: 0 20px;">';
+        $output .= '<section class="custom-related-posts">';
+        $output .= '<h2 class="related-posts-title">Related Posts</h2>';
+        $output .= '<div class="related-posts-grid">';
 
         while ( $related->have_posts() ) {
             $related->the_post();
 
-            echo '<article class="related-post-item">';
-            echo '<h3 class="related-post-title">';
-            echo '<a href="' . esc_url( get_permalink() ) . '">' . get_the_title() . '</a>';
-            echo '</h3>';
+            $output .= '<article class="related-post-item">';
+            $output .= '<h3 class="related-post-title">';
+            $output .= '<a href="' . esc_url( get_permalink() ) . '">' . get_the_title() . '</a>';
+            $output .= '</h3>';
 
             $excerpt = get_the_excerpt();
             if ( empty( $excerpt ) ) {
                 $excerpt = wp_trim_words( get_the_content(), 20, '...' );
             }
 
-            echo '<p class="related-post-excerpt">' . esc_html( $excerpt ) . '</p>';
-            echo '<a href="' . esc_url( get_permalink() ) . '" class="related-post-link">Read More →</a>';
-            echo '</article>';
+            $output .= '<p class="related-post-excerpt">' . esc_html( $excerpt ) . '</p>';
+            $output .= '<a href="' . esc_url( get_permalink() ) . '" class="related-post-link">Read More →</a>';
+            $output .= '</article>';
         }
 
-        echo '</div>';
-        echo '</section>';
-        echo '</div>';
-        echo '</div>';
+        $output .= '</div>';
+        $output .= '</section>';
+        $output .= '</div>';
+        $output .= '</div>';
     }
 
     wp_reset_postdata();
+    return $output;
 }
 
-// Hook to display at end of post content
-add_action( 'astra_entry_after', 'display_custom_related_posts', 25 );
+/**
+ * Append the related posts markup to post content.
+ *
+ * @param string $content Post content.
+ * @return string Modified content with related posts appended.
+ */
+function append_related_posts_to_content( $content ) {
+    if ( is_single() ) {
+        $content .= display_custom_related_posts();
+    }
+
+    return $content;
+}
+
+// Hook the content filter so related posts appear before any footer pattern
+add_filter( 'the_content', 'append_related_posts_to_content', 20 );


### PR DESCRIPTION
## Summary
- refactor `display_custom_related_posts()` to return markup instead of echoing
- add `append_related_posts_to_content()` to append related posts markup to the post body
- hook the wrapper with `the_content` so related posts show before footer blocks
- remove the previous `astra_entry_after` action

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68645ca49040833197938e84b0f52a14