### PR TITLE
Fix alt text in Treasury Tech Market page

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -32,7 +32,7 @@
             <h1 class="text-4xl md:text-5xl font-extrabold text-gray-900 leading-tight">Demystifying the Treasury Tech Market</h1>
             <p class="mt-6 max-w-3xl mx-auto text-lg md:text-xl text-gray-700">Choosing treasury technology can feel overwhelming. We break the landscape into three clear categories so you can chart the right path forward.</p>
             <div class="mt-10 max-w-4xl mx-auto">
-                <img loading="lazy" src="https://storage.googleapis.com/gemini-prod-us-west1-assets/e22646c2436d9367c3b24dd58572183c.png" alt="Illustration of the Treasury Tech Stack" class="rounded-xl shadow-lg w-full">
+                <img loading="lazy" src="https://storage.googleapis.com/gemini-prod-us-west1-assets/e22646c2436d9367c3b24dd58572183c.png" alt="Illustration of the Treasury Tech Portal" class="rounded-xl shadow-lg w-full">
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- fix alt text for the hero image on the Treasury Tech Market page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686579babc748331b4438870b3c5ccdf