### PR TITLE
Remove workshop banner from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1087,26 +1087,9 @@
             }
         }
 
-        /* Top Workshop Banner */
-        .workshop-banner {
-            background: var(--primary-purple);
-            color: var(--white);
-            text-align: center;
-            padding: 12px 20px;
-            font-weight: 600;
-        }
-
-        .workshop-banner a {
-            color: var(--white);
-            text-decoration: underline;
-        }
     </style>
 </head>
 <body>
-
-    <div class="workshop-banner">
-        📣 Join our live workshop on July 15th! <a href="mailto:workshop@realtreasury.com?subject=Workshop%20Registration">Register now</a>
-    </div>
 
     <!-- Hero Section -->
     <section class="hero full-bg-section section-lg">


### PR DESCRIPTION
## Summary
- delete CSS and markup for the workshop banner
- clean up extra blank line after `<body>`

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_686579f70cd88331bf6dfd6e89057b4d