### PR TITLE
Fix duplicate 'loading' attribute in insights card image

### DIFF
--- a/insights/index.html
+++ b/insights/index.html
@@ -547,7 +547,7 @@
                     card.style.animationDelay = `${index * 100}ms`;
                     const categorySpan = category ? `<span class="card-category">${category}</span>` : '';
                     card.innerHTML = `
-                        <img loading="lazy" src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" loading="lazy" alt="${post.title.rendered}" class="card-image">
+                        <img loading="lazy" src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" alt="${post.title.rendered}" class="card-image">
                         <div class="card-content">
                             ${categorySpan}
                             <h2 class="card-title">${post.title.rendered}</h2>

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -547,7 +547,7 @@
                     card.style.animationDelay = `${index * 100}ms`;
                     const categorySpan = category ? `<span class="card-category">${category}</span>` : '';
                     card.innerHTML = `
-                        <img loading="lazy" src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" loading="lazy" alt="${post.title.rendered}" class="card-image">
+                        <img loading="lazy" src="${imageUrl}" ${srcset ? `srcset="${srcset}" sizes="(max-width: 768px) 100vw, 600px"` : ''} width="${width}" height="${height}" alt="${post.title.rendered}" class="card-image">
                         <div class="card-content">
                             ${categorySpan}
                             <h2 class="card-title">${post.title.rendered}</h2>


### PR DESCRIPTION
## Summary
- remove extra `loading="lazy"` from the card image in `templates/insights/index.html`
- rebuild compiled HTML

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865979f77ac8331aba9c7ef45e1e3e5