### PR TITLE
Add All filter reset in Insights

### DIFF
--- a/insights/index.html
+++ b/insights/index.html
@@ -615,6 +615,7 @@
                         });
                     }
                 });
+                filterButtonsContainer.innerHTML = '<button class="active" data-category="all">All</button>';
                 categories.forEach(category => {
                     const button = document.createElement('button');
                     button.textContent = category;

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -615,6 +615,7 @@
                         });
                     }
                 });
+                filterButtonsContainer.innerHTML = '<button class="active" data-category="all">All</button>';
                 categories.forEach(category => {
                     const button = document.createElement('button');
                     button.textContent = category;


### PR DESCRIPTION
## Summary
- reset filter buttons before populating category filters
- rebuild HTML for `insights/index.html`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686597a375988331ab385dfc4e919294