### PR TITLE
Update workshop link on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@
                 </a>
 
                 <!-- Live Selection Workshop -->
-                <div class="feature-card">
+                <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/" class="feature-card" tabindex="0">
                     <div class="feature-icon">
                         <svg class="icon-workshop" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
                             <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/>
@@ -1173,7 +1173,7 @@
                     <div class="feature-subtitle">Group Sessions</div>
                     <h3>Live Selection Workshops</h3>
                     <p>Join a live, expert-led group workshop to align your team, cut through the vendor noise, and shortlist solutions—fast.</p>
-                </div>
+                </a>
 
                 <!-- 15-Minute Strategy Call -->
                 <a href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2?ismsaljsauthenabled" target="_blank" class="feature-card" tabindex="0">


### PR DESCRIPTION
## Summary
- enable the **Live Selection Workshops** card on the homepage to act as a link

## Testing
- `git show -U5`


------
https://chatgpt.com/codex/tasks/task_e_6865ab3a654c833188c4620ecebce16b