### PR TITLE
Fix workshops link target

### DIFF
--- a/index.html
+++ b/index.html
@@ -1164,7 +1164,7 @@
                 </a>
 
                 <!-- Live Selection Workshop -->
-                <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/" class="feature-card" tabindex="0">
+                <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/" class="feature-card" tabindex="0" target="_parent">
                     <div class="feature-icon">
                         <svg class="icon-workshop" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
                             <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/>


### PR DESCRIPTION
## Summary
- open the Live Selection Workshops link outside of the iframe

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865bcf35e288331aa55334f6ae9c3e6