### PR TITLE
Adjust search bar width on insights page

### DIFF
--- a/insights/index.html
+++ b/insights/index.html
@@ -121,7 +121,8 @@
             align-items: center;
             flex-wrap: wrap;
             gap: 1rem;
-            margin-bottom: 2.5rem;
+            margin: 0 auto 2.5rem;
+            max-width: 900px;
         }
 
         .filter-buttons {
@@ -368,7 +369,11 @@
         @media (max-width: 768px) {
             .hero-section h1 { font-size: 2.5rem; }
             .cta-banner { flex-direction: column; text-align: center; }
-            .filters-and-search { flex-direction: column; align-items: stretch; }
+            .filters-and-search {
+                flex-direction: column;
+                align-items: stretch;
+                max-width: none;
+            }
             .insights-grid { grid-template-columns: 1fr; }
         }
     </style>

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -121,7 +121,8 @@
             align-items: center;
             flex-wrap: wrap;
             gap: 1rem;
-            margin-bottom: 2.5rem;
+            margin: 0 auto 2.5rem;
+            max-width: 900px;
         }
 
         .filter-buttons {
@@ -368,7 +369,11 @@
         @media (max-width: 768px) {
             .hero-section h1 { font-size: 2.5rem; }
             .cta-banner { flex-direction: column; text-align: center; }
-            .filters-and-search { flex-direction: column; align-items: stretch; }
+            .filters-and-search {
+                flex-direction: column;
+                align-items: stretch;
+                max-width: none;
+            }
             .insights-grid { grid-template-columns: 1fr; }
         }
     </style>


### PR DESCRIPTION
## Summary
- restrict the width of the filters/search bar on the insights page
- keep search section full width on small screens

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865d500c3188331bb9e7a0acf8c7f06