### PR TITLE
Update insights grid style and posts per page

### DIFF
--- a/insights/index.html
+++ b/insights/index.html
@@ -173,11 +173,17 @@
 
         .insights-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+            grid-template-columns: repeat(3, 1fr);  /* Exactly 3 columns */
             gap: 2rem;
             min-height: 300px;
-            max-width: 800px;  /* Add this line */
-            margin: 0 auto;    /* Add this line */
+            max-width: 900px;
+            margin: 0 auto;
+        }
+        @media (max-width: 1024px) {
+            .insights-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+        @media (max-width: 768px) {
+            .insights-grid { grid-template-columns: 1fr; }
         }
         
         .loader {
@@ -494,7 +500,7 @@
 
             let allPosts = [];
             let currentPosts = [];
-            const POSTS_PER_PAGE = 12;
+            const POSTS_PER_PAGE = 6;
             let displayedCount = POSTS_PER_PAGE;
 
             // Function to create and append schema

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -173,11 +173,17 @@
 
         .insights-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+            grid-template-columns: repeat(3, 1fr);  /* Exactly 3 columns */
             gap: 2rem;
             min-height: 300px;
-            max-width: 800px;  /* Add this line */
-            margin: 0 auto;    /* Add this line */
+            max-width: 900px;
+            margin: 0 auto;
+        }
+        @media (max-width: 1024px) {
+            .insights-grid { grid-template-columns: repeat(2, 1fr); }
+        }
+        @media (max-width: 768px) {
+            .insights-grid { grid-template-columns: 1fr; }
         }
         
         .loader {
@@ -494,7 +500,7 @@
 
             let allPosts = [];
             let currentPosts = [];
-            const POSTS_PER_PAGE = 12;
+            const POSTS_PER_PAGE = 6;
             let displayedCount = POSTS_PER_PAGE;
 
             // Function to create and append schema


### PR DESCRIPTION
## Summary
- refine insights grid layout for desktop, tablet and mobile
- reduce default posts displayed to six
- rebuild HTML

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865db0d10dc83319a0485b21b3cbcc1