### PR TITLE
Improve readability on ERR NOT page

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -493,7 +493,7 @@
                 <div class="bg-white rounded-2xl p-8 border border-purple-200 shadow-md">
                     <div class="text-4xl mb-4">🎥</div>
                     <h3 class="text-xl font-bold mb-4">Watch Vendor Demos</h3>
-                    <p class="text-purple-200 mb-6 text-sm">Access our library of 50+ treasury tech demos with filters and comparisons</p>
+                    <p class="text-gray-600 mb-6 text-sm">Access our library of 50+ treasury tech demos with filters and comparisons</p>
                     <button class="open-video-modal w-full">
                         Access Demo Library
                     </button>
@@ -503,7 +503,7 @@
                 <div class="bg-white rounded-2xl p-8 border border-purple-200 shadow-md">
                     <div class="text-4xl mb-4">👥</div>
                     <h3 class="text-xl font-bold mb-4">Join Live Workshop</h3>
-                    <p class="text-purple-200 mb-6 text-sm">Group session to align your team and apply ERR NOT™ to your project</p>
+                    <p class="text-gray-600 mb-6 text-sm">Group session to align your team and apply ERR NOT™ to your project</p>
                     <a href="https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration" class="open-video-modal w-full text-center block">
                         Register for Workshop
                     </a>
@@ -513,7 +513,7 @@
                 <div class="bg-white rounded-2xl p-8 border border-purple-200 shadow-md">
                     <div class="text-4xl mb-4">📞</div>
                     <h3 class="text-xl font-bold mb-4">15-Minute Strategy Call</h3>
-                    <p class="text-purple-200 mb-6 text-sm">Free consultation to discuss your specific treasury tech selection needs</p>
+                    <p class="text-gray-600 mb-6 text-sm">Free consultation to discuss your specific treasury tech selection needs</p>
                     <a href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2" 
                        target="_blank"
                        class="open-video-modal w-full text-center block">


### PR DESCRIPTION
## Summary
- improve readability of CTA descriptions by switching to `text-gray-600`

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_6865f3ff0790833182bcbc861b76aa71