### PR TITLE
Remove Corporate Treasurer testimonial

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -400,15 +400,6 @@
                     <div class="font-bold text-purple-700">Tony Vu</div>
                     <div class="text-gray-600">Treasurer, Broward Health</div>
                 </div>
-                
-                <div class="testimonial-card">
-                    <p class="text-lg mb-6 italic">
-                        "Before this, our tech selection was a mess of conflicting opinions and vendor hype. ERR NOT™ gave us a clear, repeatable framework that got everyone aligned. It's now our standard for all future tech investments."
-                    </p>
-                    <div class="font-bold text-purple-700">Corporate Treasurer, Fortune 500 Retailer</div>
-                    <div class="text-gray-600">$15B+ Revenue</div>
-                </div>
-
                 <div class="testimonial-card">
                     <p class="text-lg mb-6 italic">
                         "They effectively implemented treasury software that seamlessly integrates cash journal entry posting and has revolutionized our financial management, providing unparalleled efficiency and insight into our cash flow operations."


### PR DESCRIPTION
## Summary
- remove Fortune 500 testimonial from ERR NOT page

## Testing
- `grep -n "Corporate Treasurer" -n errnot/index.html`


------
https://chatgpt.com/codex/tasks/task_e_6865fd42b7748331b96e1ece76e2f1a3