### PR TITLE
Unify about page stat styles

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -111,38 +111,54 @@
         /* Stat Cards */
         .stats-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-            gap: 20px;
-            margin-top: 2.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 2rem;
+            margin: 3rem 0;
         }
 
         .stat-card {
-            background: #f8f9fa;
-            padding: 24px;
+            background: linear-gradient(135deg,
+                rgba(255, 255, 255, 0.9) 0%,
+                rgba(248, 248, 248, 0.95) 100%);
+            border: 2px solid rgba(199, 125, 255, 0.2);
             border-radius: 16px;
+            padding: 2rem 1.5rem;
             text-align: center;
-            border: 1px solid #e9ecef;
-            transition: all 0.3s ease;
+            transition: all 0.4s ease;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .stat-card::before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background: linear-gradient(90deg, var(--primary-purple), var(--secondary-purple));
         }
 
         .stat-card:hover {
-             transform: translateY(-5px);
-             box-shadow: 0 8px 20px rgba(0,0,0,0.05);
-             border-color: var(--light-purple);
+            transform: translateY(-6px) scale(1.02);
+            box-shadow: 0 15px 40px rgba(114, 22, 244, 0.2);
+            border-color: rgba(199, 125, 255, 0.4);
         }
 
-        .stat-card .stat-number {
-            font-size: 2.5rem;
-            font-weight: 700;
+        .stat-number {
+            font-size: 2.8rem;
+            font-weight: 800;
             color: var(--primary-purple);
+            display: block;
             line-height: 1;
+            margin-bottom: 0.5rem;
         }
 
-        .stat-card .stat-label {
-            font-size: 0.9rem;
+        .stat-label {
             color: var(--gray-text);
-            margin-top: 0.5rem;
-            font-weight: 500;
+            font-weight: 600;
+            font-size: 1rem;
+            line-height: 1.3;
         }
 
             </style>
@@ -177,16 +193,16 @@
 
                     <div class="stats-grid">
                         <div class="stat-card">
-                            <div class="stat-number">250+</div>
-                            <div class="stat-label">Vendors Mapped</div>
+                            <span class="stat-number">250+</span>
+                            <span class="stat-label">Vendors Mapped</span>
                         </div>
                         <div class="stat-card">
-                            <div class="stat-number">80%</div>
-                            <div class="stat-label">Faster RFPs</div>
+                            <span class="stat-number">80%</span>
+                            <span class="stat-label">Faster RFPs</span>
                         </div>
                         <div class="stat-card">
-                            <div class="stat-number">50+</div>
-                            <div class="stat-label">Clients Served</div>
+                            <span class="stat-number">50+</span>
+                            <span class="stat-label">Clients Served</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update CSS for about page to match stat card design used in other pages
- switch stat markup to span elements for consistency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866062c88548331804a968044a67452