### PR TITLE
Fix inaccurate stats on home and about pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -193,7 +193,7 @@
 
                     <div class="stats-grid">
                         <div class="stat-card">
-                            <span class="stat-number">250+</span>
+                            <span class="stat-number">25+</span>
                             <span class="stat-label">Vendors Mapped</span>
                         </div>
                         <div class="stat-card">
@@ -201,7 +201,7 @@
                             <span class="stat-label">Faster RFPs</span>
                         </div>
                         <div class="stat-card">
-                            <span class="stat-number">50+</span>
+                            <span class="stat-number">25+</span>
                             <span class="stat-label">Clients Served</span>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -977,7 +977,7 @@
                     <p>Independent & Unbiased</p>
                 </div>
                 <div class="stat-item">
-                    <h3>50+</h3>
+                    <h3>25+</h3>
                     <p>Enterprise Clients</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- adjust vendor and client counts to reflect current totals on the about page
- update home page stat for consistency

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_6866079a0ad88331804831aae162100a