### PR TITLE
Remove link underlines from homepage cards

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1711,3 +1711,10 @@ body.modal-open {
     pointer-events: none;
     background: transparent;
 }
+
+/* Remove link underlines on homepage cards */
+.feature-card,
+.feature-card *,
+.team-card a {
+    text-decoration: none !important;
+}


### PR DESCRIPTION
## Summary
- ensure homepage cards do not show link underlines

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686607fdb1848331960c0c2e3e28ce21