### PR TITLE
Fix about page CTA link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -182,7 +182,7 @@
                         With a structured methodology and deep market intelligence, we've guided over 50 enterprise treasury teams through successful technology selections. We streamline the RFP process, clarify complex requirements, and empower you to make decisions with absolute confidence.
                     </p>
                     
-                    <a href="/approach" class="cta-button">Explore Our Approach</a>
+                    <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/errnot/" class="cta-button">Explore Our Approach</a>
                 </div>
 
                 <!-- Right Column: Image & Stats -->


### PR DESCRIPTION
## Summary
- fix the CTA link on the about page to point to the ERR NOT page
- run project build to verify HTML rendering

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686609437da08331949794b2b60a4d50