### PR TITLE
Fix z-index for menu

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -191,7 +191,7 @@
             .section-padding {
                 padding: 60px 0;
             }
-            
+
             .open-video-modal,
             .cta-secondary {
                 padding: 14px 24px !important;
@@ -199,6 +199,13 @@
                 width: 100%;
                 margin-bottom: 1rem;
             }
+        }
+
+        /* Ensure Max Mega Menu displays above page content */
+        #mega-menu-wrap-max_mega_menu_1,
+        #mega-menu-wrap-primary,
+        .mega-menu-wrap {
+            z-index: 99999 !important;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- bring Max Mega Menu above other content on the ERR NOT page

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_68660e0764088331b522d836d9e86c30