### PR TITLE
Fix footer workshop link

### DIFF
--- a/footer/index.html
+++ b/footer/index.html
@@ -39,7 +39,7 @@
                 <ul class="footer-links">
                     <li><a href="/">Home</a></li>
                     <li><a href="#openVideoModal">Access Demos</a></li>
-                    <li><a href="/tech-workshops">Tech Workshops</a></li>
+                    <li><a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/">Tech Workshops</a></li>
                     <li><a href="/insights">Insights</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- update Quick Links footer to point to the Tech Selection Workshop page

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_686685e4181883319a73343199b70c0a