### PR TITLE
Harmonize expert bios on ERR NOT page

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -442,41 +442,86 @@
             <h2 class="text-4xl md:text-5xl font-bold text-center mb-16">
                 Meet Your <span class="gradient-text">Experts</span>
             </h2>
-            
+            <p class="text-xl text-gray-600 text-center mb-16 max-w-3xl mx-auto">
+                We're on your side of the table. Founded by treasury professionals, Real Treasury is built to support internal finance teams with selecting the best tools for your company with confidence.
+            </p>
+
             <div class="grid grid-cols-1 md:grid-cols-2 gap-12">
-                <div class="text-center">
-                    <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600">
+                <!-- Tim's Bio -->
+                <div class="glass-card rounded-2xl p-8 text-center relative">
+                    <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600 transition-all duration-300 hover:border-purple-400 hover:shadow-lg hover:scale-105">
                         <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg"
                              alt="ERR NOT Method page headshot of Tim Schultz, Co-Founder"
                              class="w-full h-full object-cover">
                     </div>
-                    <h3 class="text-2xl font-bold mb-2">Tim</h3>
-                    <p class="text-purple-600 font-semibold mb-4">Co-Founder & Principal Consultant</p>
-                    <p class="text-gray-600">
+                    <div class="text-sm text-purple-600 font-semibold uppercase tracking-wide mb-2">Co-Founder & Principal Consultant</div>
+                    <h3 class="text-2xl font-bold mb-4 text-gray-900">Tim</h3>
+                    <p class="text-gray-600 mb-6 leading-relaxed">
                         Former treasury lead with 15+ years optimizing cash management and risk operations. Tim founded Real Treasury to democratize access to treasury technology insights and help teams make confident, informed decisions without vendor bias.
                     </p>
-                    <div class="flex justify-center space-x-4 mt-4">
-                        <a href="https://www.linkedin.com/in/schultzctp/" target="_blank" class="text-purple-600 hover:text-purple-800">LinkedIn</a>
-                        <a href="mailto:tschultz@realtreasury.com" class="text-purple-600 hover:text-purple-800">Email</a>
-                        <span class="text-gray-500">Tampa, FL</span>
+
+                    <div class="flex flex-col gap-3 items-center">
+                        <div class="flex gap-4 flex-wrap justify-center">
+                            <a href="https://www.linkedin.com/in/schultzctp/" target="_blank" 
+                               class="flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-all duration-300 text-sm font-medium">
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.761 0 5-2.239 5-5v-14c0-2.761-2.239-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
+                                </svg>
+                                LinkedIn
+                            </a>
+                            <a href="mailto:tschultz@realtreasury.com" 
+                               class="flex items-center gap-2 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 transition-all duration-300 text-sm font-medium">
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+                                </svg>
+                                Email
+                            </a>
+                        </div>
+                        <div class="flex items-center gap-2 text-gray-500 text-sm">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+                            </svg>
+                            Tampa, FL
+                        </div>
                     </div>
                 </div>
 
-                <div class="text-center">
-                    <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600">
+                <!-- Tracey's Bio -->
+                <div class="glass-card rounded-2xl p-8 text-center relative">
+                    <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600 transition-all duration-300 hover:border-purple-400 hover:shadow-lg hover:scale-105">
                         <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png"
                              alt="ERR NOT Method page headshot of Tracey Knight, Co-Founder"
-                             class="w-full h-full object-cover">
+                             class="w-full h-full object-cover object-top scale-120">
                     </div>
-                    <h3 class="text-2xl font-bold mb-2">Tracey</h3>
-                    <p class="text-purple-600 font-semibold mb-4">Co-Founder & Principal Consultant</p>
-                    <p class="text-gray-600">
+                    <div class="text-sm text-purple-600 font-semibold uppercase tracking-wide mb-2">Co-Founder & Principal Consultant</div>
+                    <h3 class="text-2xl font-bold mb-4 text-gray-900">Tracey</h3>
+                    <p class="text-gray-600 mb-6 leading-relaxed">
                         Treasury operations expert specializing in system implementations and process optimization. Tracey leads client engagements and workshop facilitation, ensuring every treasury team gets the strategic support they need during technology transitions.
                     </p>
-                    <div class="flex justify-center space-x-4 mt-4">
-                        <a href="https://www.linkedin.com/in/traceyfergusonknight/" target="_blank" class="text-purple-600 hover:text-purple-800">LinkedIn</a>
-                        <a href="mailto:tknight@realtreasury.com" class="text-purple-600 hover:text-purple-800">Email</a>
-                        <span class="text-gray-500">Dallas, TX</span>
+
+                    <div class="flex flex-col gap-3 items-center">
+                        <div class="flex gap-4 flex-wrap justify-center">
+                            <a href="https://www.linkedin.com/in/traceyfergusonknight/" target="_blank" 
+                               class="flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-all duration-300 text-sm font-medium">
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.761 0 5-2.239 5-5v-14c0-2.761-2.239-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
+                                </svg>
+                                LinkedIn
+                            </a>
+                            <a href="mailto:tknight@realtreasury.com" 
+                               class="flex items-center gap-2 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 transition-all duration-300 text-sm font-medium">
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+                                </svg>
+                                Email
+                            </a>
+                        </div>
+                        <div class="flex items-center gap-2 text-gray-500 text-sm">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/>
+                            </svg>
+                            Dallas, TX
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- sync "Meet the Experts" section on the ERR NOT page with the homepage style
- add intro paragraph and glass-card layout for each founder profile

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_6866878ec4ac8331bf6895c5a1ad3873