### PR TITLE
Fix insights page padding

### DIFF
--- a/insights/index.html
+++ b/insights/index.html
@@ -65,7 +65,7 @@
         .insights-container {
             max-width: 960px;
             margin: -4rem auto 0;
-            padding: 0 1.5rem 4rem;
+            padding: 0 3rem 4rem;
             position: relative;
             z-index: 1;
         }


### PR DESCRIPTION
## Summary
- increase padding for the `.insights-container` so content has more space

## Testing
- `grep -n "padding" insights/index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_6866889670d083319788e2e956e3285f