### PR TITLE
Replace staging URLs with production domain

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -182,7 +182,7 @@
                         With a structured methodology and deep market intelligence, we've guided over 50 enterprise treasury teams through successful technology selections. We streamline the RFP process, clarify complex requirements, and empower you to make decisions with absolute confidence.
                     </p>
                     
-                    <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/errnot/" class="cta-button">Explore Our Approach</a>
+                    <a href="https://realtreasury.com/errnot/" class="cta-button">Explore Our Approach</a>
                 </div>
 
                 <!-- Right Column: Image & Stats -->

--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1113,7 +1113,7 @@ document.addEventListener('wpcf7mailsent', function(event) {
     if (modal) modal.classList.remove('show');
     
     // Redirect immediately (no delay)
-    window.location.href = 'https://aisbee08e5bdvaliantmaker.wpcomstaging.com/treasury-tech-portal/';
+    window.location.href = 'https://realtreasury.com/treasury-tech-portal/';
 });
 </script>
 <?php

--- a/errnot/index.html
+++ b/errnot/index.html
@@ -454,7 +454,7 @@
                 <!-- Tim's Bio -->
                 <div class="glass-card rounded-2xl p-8 text-center relative">
                     <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600 transition-all duration-300 hover:border-purple-400 hover:shadow-lg hover:scale-105">
-                        <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg"
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg"
                              alt="ERR NOT Method page headshot of Tim Schultz, Co-Founder"
                              class="w-full h-full object-cover">
                     </div>
@@ -493,7 +493,7 @@
                 <!-- Tracey's Bio -->
                 <div class="glass-card rounded-2xl p-8 text-center relative">
                     <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600 transition-all duration-300 hover:border-purple-400 hover:shadow-lg hover:scale-105">
-                        <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png"
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png"
                              alt="ERR NOT Method page headshot of Tracey Knight, Co-Founder"
                              class="w-full h-full object-cover object-top scale-120">
                     </div>
@@ -559,7 +559,7 @@
                     <div class="text-4xl mb-4">👥</div>
                     <h3 class="text-xl font-bold mb-4">Join Live Workshop</h3>
                     <p class="text-gray-600 mb-6 text-sm">Group session to align your team and apply ERR NOT™ to your project</p>
-                    <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/" class="w-full text-center block cta-secondary">
+                    <a href="https://realtreasury.com/tech-selection-workshop/" class="w-full text-center block cta-secondary">
                         Register for Workshop
                     </a>
                 </div>

--- a/events/2024/afp/index.html
+++ b/events/2024/afp/index.html
@@ -191,7 +191,7 @@
                 <p class="text-lg text-gray-500 mb-6">Event in Nashville, TN | Published August 26, 2024</p>
                 
                 <div class="post-image-container">
-                    <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/AFP-Nashville.png" alt="AFP 2024 Annual Conference in Nashville" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=AFP+2024+Nashville';">
+                    <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/AFP-Nashville.png" alt="AFP 2024 Annual Conference in Nashville" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=AFP+2024+Nashville';">
                 </div>
                 
                 <p>We're excited to be a part of the AFP 2024 conference in Nashville, TN. Join our Principal, Tracey Ferguson Knight, and other industry experts for a session designed to demystify the technology selection process.</p>

--- a/events/2024/dafp/index.html
+++ b/events/2024/dafp/index.html
@@ -191,7 +191,7 @@
                 <p class="text-lg text-gray-500 mb-6">Event on September 12, 2024</p>
                 
                 <div class="post-image-container">
-                    <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Bigd-Header.png" alt="Big D Financial Conference Header" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=Big+D+Financial+Conference';">
+                    <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Bigd-Header.png" alt="Big D Financial Conference Header" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=Big+D+Financial+Conference';">
                 </div>
                 
                 <p>Join us at the 2024 Big D Financial Conference in Dallas! Our Principal, Tracey Ferguson Knight, will be presenting a can't-miss session for anyone navigating the complex world of treasury technology.</p>

--- a/events/2024/fincircle/index.html
+++ b/events/2024/fincircle/index.html
@@ -192,7 +192,7 @@
                 <p class="text-lg text-gray-500 mb-6">Podcast Episode | November 25, 2024</p>
                 
                 <div class="post-image-container">
-                    <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/20241125FINCIRCLEPodcast.png" alt="FinCircle Podcast logo featuring Real Treasury guest speaker" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=FinCircle+Podcast';">
+                    <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/20241125FINCIRCLEPodcast.png" alt="FinCircle Podcast logo featuring Real Treasury guest speaker" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=FinCircle+Podcast';">
                 </div>
                 
                 <p>We were delighted to have our Principal, Tracey Ferguson Knight, join the FinCircle Podcast to discuss one of the most transformative technologies in finance today: Artificial Intelligence.</p>

--- a/events/2024/gwafp/index.html
+++ b/events/2024/gwafp/index.html
@@ -208,7 +208,7 @@
                 <p class="text-lg text-gray-500 mb-6">Published on August 14, 2024</p>
                 
                 <div class="post-image-container">
-                    <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/GWAFP.png" alt="Real Treasury at the Greater Washington AFP event">
+                    <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/GWAFP.png" alt="Real Treasury at the Greater Washington AFP event">
                 </div>
                 
                 <p>We were thrilled to participate in the Greater Washington AFP (GWAFP) conference on August 14, 2024. Our very own Tracey Ferguson-Lazzereschi led an insightful session on a topic crucial for modern finance leaders: maximizing the value of your technology investments.</p>

--- a/events/2024/nyce/index.html
+++ b/events/2024/nyce/index.html
@@ -192,7 +192,7 @@
                 <p class="text-lg text-gray-500 mb-6">A Real Treasury Session at the TMA of New York Conference</p>
                 
                 <div class="post-image-container">
-                    <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/TMANYConference.webp" alt="TMA of New York NYCE 2024 Conference logo" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=NYCE+2024+Conference';">
+                    <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/TMANYConference.webp" alt="TMA of New York NYCE 2024 Conference logo" onerror="this.onerror=null;this.src='https://placehold.co/600x300/f0e9ff/7216f4?text=NYCE+2024+Conference';">
                 </div>
                 
                 <p>The treasury landscape is rapidly evolving, and Artificial Intelligence is at the forefront of this transformation. Real Treasury is excited to lead a critical discussion on this topic at the 2024 New York Cash Exchange (NYCE) conference.</p>

--- a/footer/index.html
+++ b/footer/index.html
@@ -17,7 +17,7 @@
             <!-- Company Info Section -->
             <div class="footer-section company-section">
                 <div class="company-logo">
-                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/White-logo-no-background.png" alt="Real Treasury" class="footer-logo">
+                    <img src="https://realtreasury.com/wp-content/uploads/2025/06/White-logo-no-background.png" alt="Real Treasury" class="footer-logo">
                 </div>
                 <p class="company-tagline">
                     <em>Guiding treasury teams to the right tech with expert advice and deep industry insight.</em>
@@ -39,8 +39,8 @@
                 <ul class="footer-links">
                     <li><a href="/">Home</a></li>
                     <li><a href="#openVideoModal">Treasury Tech Portal</a></li>
-                    <li><a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/">Tech Workshops</a></li>
-                    <li><a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/posts/">Insights</a></li>
+                    <li><a href="https://realtreasury.com/tech-selection-workshop/">Tech Workshops</a></li>
+                    <li><a href="https://realtreasury.com/posts/">Insights</a></li>
                 </ul>
             </div>
             

--- a/header/banner/index.html
+++ b/header/banner/index.html
@@ -380,7 +380,7 @@
         <button class="close-btn" onclick="closeBanner()" aria-label="Close banner">&times;</button>
         
         <div class="banner-content">
-            <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/" target="_blank" rel="noopener noreferrer">
+            <a href="https://realtreasury.com/tech-selection-workshop/" target="_blank" rel="noopener noreferrer">
                 <div class="banner-icon">🔍</div>
             </a>
             

--- a/index.html
+++ b/index.html
@@ -953,12 +953,12 @@
                     </div>
                 </div>
                 <div class="hero-image">
-                    <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/treasury-tech-market/">
+                    <a href="https://realtreasury.com/treasury-tech-market/">
                         <div class="chart-title-overlay">
                             <h3>The Treasury Tech Marketplace</h3>
                             <p>North American Vendors</p>
                         </div>
-                        <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/TMS-Marketplace-US-03-2025-no-logo-no-title.png" alt="Preview of the Treasury Tech Market dashboard">
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/TMS-Marketplace-US-03-2025-no-logo-no-title.png" alt="Preview of the Treasury Tech Market dashboard">
                     </a>
                 </div>
             </div>
@@ -1010,7 +1010,7 @@
                 </a>
 
                 <!-- Live Selection Workshop -->
-                <a href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/tech-selection-workshop/" class="feature-card" tabindex="0" target="_parent">
+                <a href="https://realtreasury.com/tech-selection-workshop/" class="feature-card" tabindex="0" target="_parent">
                     <div class="feature-icon">
                         <svg class="icon-workshop" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
                             <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/>
@@ -1047,7 +1047,7 @@
                 <!-- Tim's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                        <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Homepage headshot of Tim Schultz, Co-Founder">
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Homepage headshot of Tim Schultz, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL Consultant</div>
                     <h3 class="team-name">Tim</h3>
@@ -1082,7 +1082,7 @@
                 <!-- Tracey's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                        <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Homepage headshot of Tracey Knight, Co-Founder">
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Homepage headshot of Tracey Knight, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL CONSULTANT</div>
                     <h3 class="team-name">Tracey</h3>

--- a/insights/2024/payment-networks-explained/index.html
+++ b/insights/2024/payment-networks-explained/index.html
@@ -408,8 +408,8 @@
             <h2 class="section-title">Payment Network Architecture</h2>
             <div class="infrastructure-diagram">
                 <div style="text-align: center;">
-                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif"
-                         srcset="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 600w, https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 1200w"
+                    <img src="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif"
+                         srcset="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 600w, https://realtreasury.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 1200w"
                          width="960" height="540" loading="lazy"
                          alt="Payment Network Architecture Flow"
                          style="max-width: 100%; height: auto; border-radius: 12px; box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15);">
@@ -428,8 +428,8 @@
             
             <!-- Network Categories Visual -->
             <div style="text-align: center; margin: 3rem 0;">
-                <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png"
-                     srcset="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png 600w, https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png 1200w"
+                <img src="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Networks.png"
+                     srcset="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Networks.png 600w, https://realtreasury.com/wp-content/uploads/2025/07/Payment-Networks.png 1200w"
                      width="960" height="540" loading="lazy"
                      alt="Payment Network Categories - Digital, Peer-to-Peer, and Card Networks"
                      style="max-width: 100%; height: auto; border-radius: 16px; box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15); border: 2px solid rgba(199, 125, 255, 0.2);">

--- a/insights/index.html
+++ b/insights/index.html
@@ -7,18 +7,18 @@
     <!-- SEO & AI Optimized Meta Tags -->
     <title>Expert Insights on AI, Tech & Business Strategy | Your Company Name</title>
     <meta name="description" content="Explore cutting-edge articles and analysis from [Your Company Name]'s experts. Drive your business forward with insights on AI, technology, and market strategy.">
-    <link rel="canonical" href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url">
+    <link rel="canonical" href="https://realtreasury.com/your-insights-page-url">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url">
+    <meta property="og:url" content="https://realtreasury.com/your-insights-page-url">
     <meta property="og:title" content="Expert Insights on AI, Tech & Business Strategy | Your Company Name">
     <meta property="og:description" content="Explore cutting-edge articles on AI, technology, and market strategy to drive your business forward.">
     <meta property="og:image" content="https://placehold.co/1200x630/7216f4/FFFFFF?text=Expert+Insights">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url">
+    <meta property="twitter:url" content="https://realtreasury.com/your-insights-page-url">
     <meta property="twitter:title" content="Expert Insights on AI, Tech & Business Strategy | Your Company Name">
     <meta property="twitter:description" content="Explore cutting-edge articles on AI, technology, and market strategy to drive your business forward.">
     <meta property="twitter:image" content="https://placehold.co/1200x630/7216f4/FFFFFF?text=Expert+Insights">
@@ -485,7 +485,7 @@
         {
           "@type": "Organization",
           "name": "Your Company Name",
-          "url": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com",
+          "url": "https://realtreasury.com",
           "logo": "https://placehold.co/200x60/281345/FFFFFF?text=Your+Logo",
           "sameAs": [
             "https://twitter.com/yourprofile",
@@ -494,7 +494,7 @@
         },
         {
           "@type": "WebPage",
-          "url": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url",
+          "url": "https://realtreasury.com/your-insights-page-url",
           "name": "Expert Insights on AI, Tech & Business Strategy",
           "description": "Explore cutting-edge articles and analysis from [Your Company Name]'s experts. Drive your business forward with insights on AI, technology, and market strategy.",
           "publisher": {
@@ -508,12 +508,12 @@
             "@type": "ListItem",
             "position": 1,
             "name": "Home",
-            "item": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com"
+            "item": "https://realtreasury.com"
           },{
             "@type": "ListItem",
             "position": 2,
             "name": "Insights",
-            "item": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url"
+            "item": "https://realtreasury.com/your-insights-page-url"
           }]
         }
       ]

--- a/team/index.html
+++ b/team/index.html
@@ -730,7 +730,7 @@
                 <!-- Tim's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                            <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Team page headshot of Tim Schultz, Co-Founder">
+                            <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Tim-Schultz-website-headshot_046.jpg" alt="Team page headshot of Tim Schultz, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL Consultant</div>
                     <h3 class="team-name">Tim</h3>
@@ -765,7 +765,7 @@
                 <!-- Tracey's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                            <img loading="lazy" src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Team page headshot of Tracey Knight, Co-Founder">
+                            <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/06/Tracey-Headshot-Website.png" alt="Team page headshot of Tracey Knight, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL CONSULTANT</div>
                     <h3 class="team-name">Tracey</h3>

--- a/templates/insights/2024/payment-networks-explained/index.html
+++ b/templates/insights/2024/payment-networks-explained/index.html
@@ -395,8 +395,8 @@
             <h2 class="section-title">Payment Network Architecture</h2>
             <div class="infrastructure-diagram">
                 <div style="text-align: center;">
-                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif"
-                         srcset="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 600w, https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 1200w"
+                    <img src="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif"
+                         srcset="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 600w, https://realtreasury.com/wp-content/uploads/2025/07/Payment-Network-GIF.gif 1200w"
                          width="960" height="540" loading="lazy"
                          alt="Payment Network Architecture Flow"
                          style="max-width: 100%; height: auto; border-radius: 12px; box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15);">
@@ -415,8 +415,8 @@
             
             <!-- Network Categories Visual -->
             <div style="text-align: center; margin: 3rem 0;">
-                <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png"
-                     srcset="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png 600w, https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Payment-Networks.png 1200w"
+                <img src="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Networks.png"
+                     srcset="https://realtreasury.com/wp-content/uploads/2025/07/Payment-Networks.png 600w, https://realtreasury.com/wp-content/uploads/2025/07/Payment-Networks.png 1200w"
                      width="960" height="540" loading="lazy"
                      alt="Payment Network Categories - Digital, Peer-to-Peer, and Card Networks"
                      style="max-width: 100%; height: auto; border-radius: 16px; box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15); border: 2px solid rgba(199, 125, 255, 0.2);">

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -7,18 +7,18 @@
     <!-- SEO & AI Optimized Meta Tags -->
     <title>Expert Insights on AI, Tech & Business Strategy | Your Company Name</title>
     <meta name="description" content="Explore cutting-edge articles and analysis from [Your Company Name]'s experts. Drive your business forward with insights on AI, technology, and market strategy.">
-    <link rel="canonical" href="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url">
+    <link rel="canonical" href="https://realtreasury.com/your-insights-page-url">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url">
+    <meta property="og:url" content="https://realtreasury.com/your-insights-page-url">
     <meta property="og:title" content="Expert Insights on AI, Tech & Business Strategy | Your Company Name">
     <meta property="og:description" content="Explore cutting-edge articles on AI, technology, and market strategy to drive your business forward.">
     <meta property="og:image" content="https://placehold.co/1200x630/7216f4/FFFFFF?text=Expert+Insights">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url">
+    <meta property="twitter:url" content="https://realtreasury.com/your-insights-page-url">
     <meta property="twitter:title" content="Expert Insights on AI, Tech & Business Strategy | Your Company Name">
     <meta property="twitter:description" content="Explore cutting-edge articles on AI, technology, and market strategy to drive your business forward.">
     <meta property="twitter:image" content="https://placehold.co/1200x630/7216f4/FFFFFF?text=Expert+Insights">
@@ -485,7 +485,7 @@
         {
           "@type": "Organization",
           "name": "Your Company Name",
-          "url": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com",
+          "url": "https://realtreasury.com",
           "logo": "https://placehold.co/200x60/281345/FFFFFF?text=Your+Logo",
           "sameAs": [
             "https://twitter.com/yourprofile",
@@ -494,7 +494,7 @@
         },
         {
           "@type": "WebPage",
-          "url": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url",
+          "url": "https://realtreasury.com/your-insights-page-url",
           "name": "Expert Insights on AI, Tech & Business Strategy",
           "description": "Explore cutting-edge articles and analysis from [Your Company Name]'s experts. Drive your business forward with insights on AI, technology, and market strategy.",
           "publisher": {
@@ -508,12 +508,12 @@
             "@type": "ListItem",
             "position": 1,
             "name": "Home",
-            "item": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com"
+            "item": "https://realtreasury.com"
           },{
             "@type": "ListItem",
             "position": 2,
             "name": "Insights",
-            "item": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/your-insights-page-url"
+            "item": "https://realtreasury.com/your-insights-page-url"
           }]
         }
       ]

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -464,7 +464,7 @@
                 <p class="hero-subtitle">Three clear categories to help you navigate 200+ treasury technology solutions and find the perfect fit for your organization.</p>
                 
                 <div class="hero-image">
-                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/07/Portal-Landing.png" alt="Treasury Tech Portal" loading="lazy">
+                    <img src="https://realtreasury.com/wp-content/uploads/2025/07/Portal-Landing.png" alt="Treasury Tech Portal" loading="lazy">
                 </div>
 
                 <div class="stats-grid">
@@ -493,7 +493,7 @@
                     <p>The treasury technology market has exploded with innovation, creating hundreds of solutions across different categories and price points. Understanding which category fits your needs is the first step to making the right investment.</p>
                 </div>
                 <div class="market-image">
-                    <img src="https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/TMS-Marketplace-US-03-2025-no-logo-no-title.png" alt="Treasury Tech Market Map" loading="lazy">
+                    <img src="https://realtreasury.com/wp-content/uploads/2025/06/TMS-Marketplace-US-03-2025-no-logo-no-title.png" alt="Treasury Tech Market Map" loading="lazy">
                 </div>
             </div>
         </div>

--- a/treasury-tech-portal/index.html
+++ b/treasury-tech-portal/index.html
@@ -2065,9 +2065,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         "desc": "Market-leading cloud treasury platform serving 3,000+ global clients with AI-powered cash forecasting, comprehensive risk management, and advanced derivatives trading capabilities.",
                         "features": ["AI-driven cash forecasting", "Real-time risk analytics", "Derivatives management", "Multi-bank connectivity", "Regulatory compliance", "Hedge accounting automation"],
                         "target": "Large enterprises and multinational corporations with complex treasury operations",
-                        "videoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/kyriba-06-2025/",
+                        "videoUrl": "https://realtreasury.com/kyriba-06-2025/",
                         "websiteUrl": "https://www.kyriba.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Kyriba.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Kyriba.png"
                     }, {
                         "name": "GTreasury",
                         "category": "TRMS",
@@ -2076,7 +2076,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Fortune 500 companies requiring complex consolidation and reporting",
                         "videoUrl": "https://youtu.be/06Kjx3X748I?si=inoxdyJF9LEfuP_j",
                         "websiteUrl": "https://gtreasury.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/GTreasury.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/GTreasury.png"
                     }, {
                         "name": "Reval",
                         "category": "TRMS",
@@ -2085,7 +2085,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Financial institutions and corporations with complex derivative portfolios",
                         "videoUrl": "https://youtu.be/WTYKRBzst-w?si=YiP8RFt1VOkFwH0o",
                         "websiteUrl": "https://iongroup.com/products/treasury/reval/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ION-Treasury.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png"
                     }, {
                         "name": "Quantum",
                         "category": "TRMS",
@@ -2093,7 +2093,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Real-time risk monitoring", "Portfolio optimization", "Stress testing", "Automated hedging", "Compliance controls", "Advanced analytics"],
                         "target": "Investment banks and large financial institutions",
                         "videoUrl": "https://youtu.be/RAWH8-FUdpQ?si=2E8JU7N-pP0rtqUr",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/FIS.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/FIS.png"
                     }, {
                         "name": "WallStreet Suite",
                         "category": "TRMS",
@@ -2102,14 +2102,14 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Large banks and corporations requiring full-scale treasury operations",
                         "videoUrl": "https://youtu.be/WTYKRBzst-w?si=YiP8RFt1VOkFwH0o",
                         "websiteUrl": "https://iongroup.com/products/treasury/wallstreet-suite/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ION-Treasury.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png"
                     }, {
                         "name": "ATOM",
                         "category": "TRMS",
                         "desc": "Enterprise treasury platform focused on derivatives trading, risk management, and automated workflow processing for sophisticated financial operations.",
                         "features": ["Derivatives trading", "Automated workflows", "Risk management", "Trade processing", "Compliance monitoring", "Real-time analytics"],
                         "target": "Large corporations and financial institutions with active trading operations",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ATOM-TM.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/ATOM-TM.png"
                     }, {
                         "name": "Integrity",
                         "category": "TRMS",
@@ -2117,7 +2117,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Governance controls", "Audit trails", "Compliance management", "Policy enforcement", "Risk controls", "Workflow approval"],
                         "target": "Highly regulated industries requiring strict governance and compliance",
                         "videoUrl": "https://youtu.be/RAWH8-FUdpQ?si=2E8JU7N-pP0rtqUr",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/FIS.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/FIS.png"
                     }, {
                         "name": "IT2",
                         "category": "TRMS",
@@ -2126,7 +2126,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Large enterprises seeking integrated treasury technology solutions",
                         "videoUrl": "https://youtu.be/WTYKRBzst-w?si=YiP8RFt1VOkFwH0o",
                         "websiteUrl": "https://iongroup.com/products/treasury/it2/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ION-Treasury.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png"
                     }, {
                         "name": "Datalog",
                         "category": "TRMS",
@@ -2135,7 +2135,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Large corporations requiring sophisticated analytics and reporting",
                         "videoUrl": "https://youtu.be/qX_iOGiuNwM?si=omRZs79-y3pyZRdk",
                         "websiteUrl": "https://www.datalog-finance.com/en/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Datalog-logo.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Datalog-logo.png"
                     }, {
                         "name": "Coupa",
                         "category": "TRMS",
@@ -2144,7 +2144,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Large enterprises requiring integrated spend and treasury management",
                         "videoUrl": "https://youtu.be/NSeXuo6f-dw?si=sxvZ3KpwVcPA8eMC",
                         "websiteUrl": "https://www.coupa.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Coupa.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Coupa.png"
                     }, {
                         "name": "Treasury Cube",
                         "category": "TRMS",
@@ -2152,7 +2152,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Modular design", "Customizable features", "Scalable architecture", "Growth-focused", "Flexible pricing", "Configurable workflows"],
                         "target": "Growing companies requiring scalable and customizable treasury solutions",
                         "websiteUrl": "https://treasurycube.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Treasury-Cube.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Treasury-Cube.png"
                     },
 
                     // CASH
@@ -2164,7 +2164,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Mid to large companies seeking AI-driven cash management solutions",
                         "videoUrl": "https://youtu.be/Vx4At4BN-og",
                         "websiteUrl": "https://trovata.io/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Trovata.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Trovata.png"
                     }, {
                         "name": "Tesorio",
                         "category": "CASH",
@@ -2172,7 +2172,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["ML optimization", "Automated forecasting", "Scenario planning", "Workflow automation", "Integration tools", "Performance analytics"],
                         "target": "Growth companies and mid-market businesses optimizing cash flow",
                         "websiteUrl": "https://www.tesorio.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Tesorio.jpg"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Tesorio.jpg"
                     }, {
                         "name": "Autocash",
                         "category": "CASH",
@@ -2181,7 +2181,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Tech-forward companies embracing AI-driven financial operations",
                         "videoUrl": "https://youtu.be/vcSdH5wcx5c?si=rhvCylzfg54nLuxB",
                         "websiteUrl": "https://www.autocash.ai/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/AutoCash.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/AutoCash.png"
                     }, {
                         "name": "Balance",
                         "category": "CASH",
@@ -2189,7 +2189,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Real-time visibility", "Auto reconciliation", "Multi-currency", "Cash positioning", "Bank connectivity", "Streamlined UX"],
                         "target": "Companies needing real-time cash visibility and automated reconciliation",
                         "websiteUrl": "https://www.balancecash.io/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Balance-Cash.jpg"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Balance-Cash.jpg"
                     }, {
                         "name": "Nilus",
                         "category": "CASH",
@@ -2197,7 +2197,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Advanced forecasting", "Scenario planning", "Variance analysis", "Performance tracking", "Budget integration", "Precision modeling"],
                         "target": "Companies requiring sophisticated cash forecasting and scenario analysis",
                         "websiteUrl": "https://www.nilus.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Nilus.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Nilus.png"
                     }, {
                         "name": "Obol",
                         "category": "CASH",
@@ -2206,7 +2206,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Modern finance teams seeking digital-first cash management solutions",
                         "videoUrl": "https://youtu.be/7XGzkaVSZzc?si=uxCD7HYRUmssywNa",
                         "websiteUrl": "https://www.obol.app/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Obol.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Obol.png"
                     }, {
                         "name": "Panax",
                         "category": "CASH",
@@ -2215,7 +2215,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Companies focused on working capital optimization and payment timing",
                         "videoUrl": "https://youtu.be/p2svAyM74nI?si=zFPF_QZkgBo2rbz8",
                         "websiteUrl": "https://www.thepanax.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Panax.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Panax.png"
                     }, {
                         "name": "Statement",
                         "category": "CASH",
@@ -2223,7 +2223,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Automated processing", "Data extraction", "Reconciliation tools", "Data validation", "Exception handling", "API integration"],
                         "target": "Companies seeking automated bank statement processing and data extraction",
                         "websiteUrl": "https://www.statement.io/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Statement.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Statement.png"
                     }, {
                         "name": "Treasury Suite",
                         "category": "CASH",
@@ -2231,16 +2231,16 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Comprehensive suite", "Cash forecasting", "Liquidity optimization", "Workflow management", "Bank connectivity", "Integrated platform"],
                         "target": "Companies requiring a complete cash management suite with integrated functionality",
                         "websiteUrl": "https://www.treasurysuite.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Treasury-Suite-Logo-PNG.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Treasury-Suite-Logo-PNG.png"
                     }, {
                         "name": "Vesto",
                         "category": "CASH",
                         "desc": "Cash positioning platform offering multibank cash flow monitoring and liquidity management capabilities.",
                         "features": ["Yield optimization", "Risk monitoring", "Investment tracking", "Liquidity management", "Performance analytics", "Compliance tools"],
                         "target": "Companies with significant cash positions seeking yield optimization",
-                        "videoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Vesto-06-2025.mp4",
+                        "videoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Vesto-06-2025.mp4",
                         "websiteUrl": "https://www.vesto.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Vesto.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Vesto.png"
                     },
 
                     // LITE
@@ -2252,7 +2252,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Mid-market companies seeking accessible treasury management solutions",
                         "videoUrl": "https://youtu.be/WTYKRBzst-w?si=YiP8RFt1VOkFwH0o",
                         "websiteUrl": "https://iongroup.com/products/treasury/treasura/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ION-Treasury.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png"
                     }, {
                         "name": "Treasury Curve",
                         "category": "LITE",
@@ -2261,7 +2261,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Companies seeking simplified treasury management with core functionality",
                         "videoUrl": "https://youtu.be/5pD7P1fOYPU?si=lgolb0x0I9dJWTcv",
                         "websiteUrl": "https://www.treasurycurve.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Treasury-Curve.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Treasury-Curve.png"
                     }, {
                         "name": "Bottomline",
                         "category": "LITE",
@@ -2269,7 +2269,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "features": ["Payment automation", "Fraud protection", "Banking integration", "Multi-bank support", "Security controls", "Workflow tools"],
                         "target": "Companies prioritizing payment automation and banking integration",
                         "websiteUrl": "https://www.bottomline.com/us?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/bottomline-technologies-logo.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/bottomline-technologies-logo.png"
                     }, {
                         "name": "City Financials",
                         "category": "LITE",
@@ -2278,7 +2278,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Mid-market companies seeking practical and growth-oriented solutions",
                         "videoUrl": "https://youtu.be/WTYKRBzst-w?si=YiP8RFt1VOkFwH0o",
                         "websiteUrl": "https://iongroup.com/products/treasury/city-financials/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/ION-Treasury.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png"
                     }, {
                         "name": "HighRadius",
                         "category": "LITE",
@@ -2287,7 +2287,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Companies seeking AI-powered automation for A/R and treasury operations",
                         "videoUrl": "https://youtu.be/B0gngAz85js?si=K2r1E4GwX5VaGwVn",
                         "websiteUrl": "https://www.highradius.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/High-Radius.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/High-Radius.png"
                     }, {
                         "name": "Treasury4",
                         "category": "LITE",
@@ -2296,7 +2296,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         "target": "Modern finance teams seeking next-generation treasury technology",
                         "videoUrl": "https://youtu.be/dYBPUYNZ_nE?si=BHMRUFAYJlvs1a6P",
                         "websiteUrl": "https://www.treasury4.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral",
-                        "logoUrl": "https://aisbee08e5bdvaliantmaker.wpcomstaging.com/wp-content/uploads/2025/06/Treasury4Logo-GraphiteGreen.png"
+                        "logoUrl": "https://realtreasury.com/wp-content/uploads/2025/06/Treasury4Logo-GraphiteGreen.png"
                     }
                 ];
 


### PR DESCRIPTION
## Summary
- swap old staging domain with realtreasury.com
- update header banner link
- fix references in events, portal, and insight pages
- update footer and about pages with production domain

## Testing
- `grep -R "wpcomstaging" -n`

------
https://chatgpt.com/codex/tasks/task_e_6866e1f0ed808331b99261e10a28717a