### PR TITLE
Remove hero stats on tech market page

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -83,35 +83,6 @@
             display: block;
         }
 
-        .stats-grid {
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-            gap: 32px;
-            max-width: 450px;
-            margin: 0 auto;
-        }
-
-        .stat {
-            text-align: center;
-        }
-
-        .stat-number {
-            font-size: 44px;
-            font-weight: 900;
-            background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-            line-height: 1;
-            margin-bottom: 6px;
-        }
-
-        .stat-label {
-            color: var(--text-light);
-            font-weight: 600;
-            font-size: 14px;
-        }
-
         /* Market Section */
         .market-section {
             padding: 80px 0;
@@ -437,13 +408,6 @@
                 padding: 28px;
             }
 
-            .stats-grid {
-                gap: 20px;
-            }
-
-            .stat-number {
-                font-size: 32px;
-            }
 
             .cta-content h2 {
                 font-size: 32px;
@@ -467,20 +431,6 @@
                     <img src="https://realtreasury.com/wp-content/uploads/2025/07/Portal-Landing.png" alt="Treasury Tech Portal" loading="lazy">
                 </div>
 
-                <div class="stats-grid">
-                    <div class="stat">
-                        <div class="stat-number">200+</div>
-                        <div class="stat-label">Solutions</div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-number">3</div>
-                        <div class="stat-label">Categories</div>
-                    </div>
-                    <div class="stat">
-                        <div class="stat-number">1000+</div>
-                        <div class="stat-label">Companies</div>
-                    </div>
-                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- remove stats block from the Treasury Tech Market hero section
- clean up related CSS

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_6866e46d244083318d0310bfd8c073af