### PR TITLE
Set default from address for emails

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1553,4 +1553,12 @@ function final_mega_menu_widget_fix() {
     wp_add_inline_script('jquery-core', $script);
 }
 add_action('wp_enqueue_scripts', 'final_mega_menu_widget_fix', 99);
+
+// Set global "from" address for all WordPress emails
+add_filter('wp_mail_from', function() {
+    return 'noreply@realtreasury.com';
+});
+add_filter('wp_mail_from_name', function() {
+    return 'Real Treasury';
+});
 ?>


### PR DESCRIPTION
## Summary
- set global `wp_mail_from` and `wp_mail_from_name` filters to use noreply@realtreasury.com

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68670edc1fac8331823acfc7748ea89c