### PR TITLE
Change widget sync frequency

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1545,7 +1545,7 @@ function final_mega_menu_widget_fix() {
             }
 
             // Run this check 10 times per second to keep everything in sync.
-            setInterval(syncWidgetState, 100);
+            setInterval(syncWidgetState, 1000);
         }
     });
     ";


### PR DESCRIPTION
## Summary
- adjust `setInterval` in PHP script to run once per second instead of 10 times per second

## Testing
- `grep -n "setInterval(syncWidgetState" -n assets/php/functions.php`

------
https://chatgpt.com/codex/tasks/task_e_68671ba6ec508331b812a0d5d8861ce7