### PR TITLE
Fix footer heading color

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1718,6 +1718,13 @@ nav[class*="post-navigation"],
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3) !important;
 }
 
+/* Ensure footer headings stay white even without the modern-footer wrapper */
+footer .footer-heading,
+footer h3.footer-heading {
+    color: #ffffff !important;
+    font-weight: 700 !important;
+}
+
 /* Additional specificity in case needed */
 .modern-footer .footer-section .footer-heading,
 .modern-footer h3.footer-heading {


### PR DESCRIPTION
## Summary
- ensure `.footer-heading` elements render white, even if `.modern-footer` wrapper isn't used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867233f16488331819009969ec5a870