### PR TITLE
Restrict REST API CORS origin

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1426,7 +1426,8 @@ add_filter('rest_jsonp_enabled', '__return_true');
 add_action('rest_api_init', function() {
     remove_filter('rest_pre_serve_request', 'rest_send_cors_headers');
     add_filter('rest_pre_serve_request', function($value) {
-        header('Access-Control-Allow-Origin: *');
+        $allowed_origin = getenv('RT_ALLOWED_ORIGIN') ?: 'https://realtreasury.com';
+        header('Access-Control-Allow-Origin: ' . $allowed_origin);
         header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
         header('Access-Control-Allow-Headers: Authorization, Content-Type');
         header('Access-Control-Allow-Credentials: true');


### PR DESCRIPTION
## Summary
- restrict REST API CORS to https://realtreasury.com
- allow overriding the allowed origin with the `RT_ALLOWED_ORIGIN` environment variable

## Testing
- `npm install`
- `npm run build`
- `curl -I -H "Origin: https://realtreasury.com" -H "Cookie: test=1" https://realtreasury.com/wp-json/ 2>&1 | head` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68674d7654d88331b85af10735939a0b