### PR TITLE
Replace deprecated video modal links

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -860,8 +860,8 @@ function add_video_modal_script() {
         // Enhanced button click handlers
         document.addEventListener('click', function(e) {
             // Open modal buttons
-            if (e.target.matches('a[href="#openVideoModal"]') ||
-                e.target.closest('a[href="#openVideoModal"]') ||
+            if (e.target.matches('a[href="#openPortalModal"]') ||
+                e.target.closest('a[href="#openPortalModal"]') ||
                 e.target.matches('.open-video-modal') ||
                 e.target.closest('.open-video-modal')) {
                 e.preventDefault();
@@ -886,10 +886,10 @@ function add_video_modal_script() {
             }
         });
 
-        // Handle menu clicks (#openVideoModal)
+        // Handle menu clicks (#openPortalModal)
         document.addEventListener('click', function(e) {
-            if (e.target.getAttribute('href') === '#openVideoModal' ||
-                e.target.closest('a[href="#openVideoModal"]')) {
+            if (e.target.getAttribute('href') === '#openPortalModal' ||
+                e.target.closest('a[href="#openPortalModal"]')) {
                 e.preventDefault();
                 openModal();
             }
@@ -1150,8 +1150,8 @@ function add_modal_bridge_script() {
     ?>
     <script>
     window.addEventListener('message', function(event) {
-        if (event.data && event.data.action === 'openVideoModal') {
-            const modalTrigger = document.querySelector('a[href="#openVideoModal"]');
+        if (event.data && event.data.action === 'openPortalModal') {
+            const modalTrigger = document.querySelector('a[href="#openPortalModal"]');
             if (modalTrigger) {
                 modalTrigger.click();
             }

--- a/errnot/index.html
+++ b/errnot/index.html
@@ -612,13 +612,13 @@
                     // Try to trigger the WordPress modal system
                     if (window.parent && window.parent !== window) {
                         // We're in an iframe, send message to parent
-                        window.parent.postMessage({ 
-                            action: 'openVideoModal',
+                        window.parent.postMessage({
+                            action: 'openPortalModal',
                             source: 'err-not-page'
                         }, '*');
                     } else {
                         // We're in main window, look for modal
-                        const modalTrigger = document.querySelector('a[href="#openVideoModal"]');
+                        const modalTrigger = document.querySelector('a[href="#openPortalModal"]');
                         if (modalTrigger) {
                             modalTrigger.click();
                         } else {

--- a/footer/index.html
+++ b/footer/index.html
@@ -31,7 +31,7 @@
                 <h3 class="footer-heading">Quick Links</h3>
                 <ul class="footer-links">
                     <li><a href="/">Home</a></li>
-                    <li><a href="#openVideoModal">Treasury Tech Portal</a></li>
+                    <li><a href="#openPortalModal">Access Portal</a></li>
                     <li><a href="https://realtreasury.com/tech-selection-workshop/">Tech Workshops</a></li>
                     <li><a href="https://realtreasury.com/posts/">Insights</a></li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -948,7 +948,7 @@
                     <h1>Real Treasury,<br>Real Results</h1>
                     <p class="lead">Helping companies select and connect to the right treasury technology – fast, unbiased, and vendor-smart.</p>
                     <div class="hero-buttons">
-                        <a href="#openVideoModal" class="btn btn-primary">Explore the Treasury Tech Portal</a>
+                        <a href="#openPortalModal" class="btn btn-primary">Access Portal</a>
                         <a href="#meet-the-team" class="btn btn-outline">Meet Our Team</a>
                     </div>
                 </div>
@@ -998,7 +998,7 @@
             </div>
             <div class="features-grid">
                 <!-- Treasury Tech Portal -->
-                <a href="#openVideoModal" class="feature-card" tabindex="0">
+                <a href="#openPortalModal" class="feature-card" tabindex="0">
                     <div class="feature-icon">
                         <svg class="icon-search" viewBox="0 0 24 24">
                             <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
@@ -1136,7 +1136,7 @@
             <div class="cta-content">
                 <h2>Ready to Transform Your Treasury Tech Search?</h2>
                 <p class="lead">Access our FREE Treasury Tech Portal and start narrowing your shortlist in minutes, not months.</p>
-                <a href="#openVideoModal" class="btn btn-primary">Get Instant Access</a>
+                <a href="#openPortalModal" class="btn btn-primary">Access Portal</a>
             </div>
         </div>
     </section>
@@ -1145,7 +1145,7 @@
     // Script to handle modal opening via postMessage for iframe communication
     document.addEventListener("DOMContentLoaded", function() {
         // Correctly select all anchor tags with the specific href
-        const modalButtons = document.querySelectorAll('a[href="#openVideoModal"]');
+        const modalButtons = document.querySelectorAll('a[href="#openPortalModal"]');
         
         modalButtons.forEach(button => {
             button.addEventListener("click", function(e) {
@@ -1154,7 +1154,7 @@
                     try {
                         // Send a message to the parent window to open the modal
                         window.parent.postMessage({
-                            action: "openVideoModal",
+                            action: "openPortalModal",
                             source: "treasury-homepage"
                         }, "*");
                         e.preventDefault(); // Prevent the default anchor behavior

--- a/insights/2024/real-treasury-explained/index.html
+++ b/insights/2024/real-treasury-explained/index.html
@@ -674,9 +674,7 @@
                 </div>
 
                 <div class="hero-cta fade-in-up animate-delay-3">
-                    <a href="#openVideoModal" class="btn-primary">
-                        🎥 Watch 3-Min Demo
-                    </a>
+                    <a href="#openPortalModal" class="btn-primary">Access Portal</a>
                     <a href="#roi-calculator" class="btn-secondary">
                         💰 Calculate Your Savings
                     </a>
@@ -789,7 +787,7 @@
                         </li>
                     </ul>
                     
-                    <a href="#openVideoModal" class="btn-primary">See It In Action</a>
+                    <a href="#openPortalModal" class="btn-primary">Access Portal</a>
                 </div>
                 
                 <div class="solution-visual">
@@ -849,7 +847,7 @@
                 </div>
                 
                 <div style="text-align: center; margin-top: 32px;">
-                    <a href="#openVideoModal" class="btn-primary">Get Detailed ROI Analysis</a>
+                    <a href="#openPortalModal" class="btn-primary">Access Portal</a>
                 </div>
             </div>
         </div>
@@ -896,9 +894,7 @@
                 <p class="cta-description">Join hundreds of finance leaders who've revolutionized their treasury operations. See our platform in action with a personalized demo.</p>
                 
                 <div class="cta-buttons">
-                    <a href="#openVideoModal" class="btn-white">
-                        🎥 Watch Demo (3 mins)
-                    </a>
+                    <a href="#openPortalModal" class="btn-white">Access Portal</a>
                     <a href="/contact" class="btn-outline">
                         📞 Schedule Live Demo
                     </a>
@@ -939,7 +935,7 @@
         // Smooth scrolling for anchor links
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {
-                if (this.getAttribute('href') !== '#openVideoModal') {
+                if (this.getAttribute('href') !== '#openPortalModal') {
                     e.preventDefault();
                     const target = document.querySelector(this.getAttribute('href'));
                     if (target) {

--- a/team/index.html
+++ b/team/index.html
@@ -715,7 +715,7 @@
                 <h1>Meet the Founders</h1>
                 <p class="lead">Treasury professionals who understand your challenges because we've been in your shoes.</p>
                 <div class="hero-buttons">
-                    <a href="#openVideoModal" class="btn btn-primary">Explore the Treasury Tech Portal</a>
+                    <a href="#openPortalModal" class="btn btn-primary">Access Portal</a>
                     <a href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2?ismsaljsauthenabled" target="_blank" class="btn btn-outline">Schedule Strategy Call</a>
                     <button onclick="openTawkChat()" class="btn btn-chat">Chat With Us Now</button>
                 </div>

--- a/templates/insights/2024/real-treasury-explained/index.html
+++ b/templates/insights/2024/real-treasury-explained/index.html
@@ -664,9 +664,7 @@
                 </div>
 
                 <div class="hero-cta fade-in-up animate-delay-3">
-                    <a href="#openVideoModal" class="btn-primary">
-                        🎥 Watch 3-Min Demo
-                    </a>
+                    <a href="#openPortalModal" class="btn-primary">Access Portal</a>
                     <a href="#roi-calculator" class="btn-secondary">
                         💰 Calculate Your Savings
                     </a>
@@ -775,7 +773,7 @@
                         </li>
                     </ul>
                     
-                    <a href="#openVideoModal" class="btn-primary">See It In Action</a>
+                    <a href="#openPortalModal" class="btn-primary">Access Portal</a>
                 </div>
                 
                 <div class="solution-visual">
@@ -835,7 +833,7 @@
                 </div>
                 
                 <div style="text-align: center; margin-top: 32px;">
-                    <a href="#openVideoModal" class="btn-primary">Get Detailed ROI Analysis</a>
+                    <a href="#openPortalModal" class="btn-primary">Access Portal</a>
                 </div>
             </div>
         </div>
@@ -882,9 +880,7 @@
                 <p class="cta-description">Join hundreds of finance leaders who've revolutionized their treasury operations. See our platform in action with a personalized demo.</p>
                 
                 <div class="cta-buttons">
-                    <a href="#openVideoModal" class="btn-white">
-                        🎥 Watch Demo (3 mins)
-                    </a>
+                    <a href="#openPortalModal" class="btn-white">Access Portal</a>
                     <a href="/contact" class="btn-outline">
                         📞 Schedule Live Demo
                     </a>
@@ -925,7 +921,7 @@
         // Smooth scrolling for anchor links
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {
-                if (this.getAttribute('href') !== '#openVideoModal') {
+                if (this.getAttribute('href') !== '#openPortalModal') {
                     e.preventDefault();
                     const target = document.querySelector(this.getAttribute('href'));
                     if (target) {


### PR DESCRIPTION
## Summary
- migrate `#openVideoModal` links to `#openPortalModal`
- update modal bridge script in PHP and HTML pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68680ead4974833197393a34bdc83889