### PR TITLE
Add header and admin bar cleanup

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -754,4 +754,115 @@ add_action('admin_footer', function() {
         echo '<script>console.log("REST API Status:", ' . json_encode($status) . ');</script>';
     }
 });
+
+// =================================================================
+// ADDITIONAL CUSTOMIZATIONS: DISABLE WORDPRESS HEADER ELEMENTS
+// =================================================================
+
+// 1. DISABLE WORDPRESS ADMIN BAR FOR ALL USERS
+add_action('after_setup_theme', 'remove_admin_bar');
+function remove_admin_bar() {
+    if (!current_user_can('administrator') && !is_admin()) {
+        show_admin_bar(false);
+    }
+}
+
+// 2. REMOVE ADMIN BAR EVEN FOR ADMINS ON FRONTEND
+add_filter('show_admin_bar', '__return_false');
+
+// 3. DISABLE THEME HEADER AND NAVIGATION
+add_action('init', 'disable_theme_header_elements');
+function disable_theme_header_elements() {
+    // Remove theme support for menus if you want to completely disable them
+    // remove_theme_support('menus');
+
+    // Remove header image support
+    remove_theme_support('custom-header');
+
+    // Remove custom logo support if conflicting
+    // remove_theme_support('custom-logo');
+}
+
+// 4. DEQUEUE ADMIN BAR CSS AND JS
+add_action('wp_enqueue_scripts', 'remove_admin_bar_assets');
+function remove_admin_bar_assets() {
+    wp_dequeue_style('admin-bar');
+    wp_dequeue_script('admin-bar');
+}
+
+// 5. REMOVE ADMIN BAR FROM HEAD
+remove_action('wp_head', '_admin_bar_bump_cb');
+
+// 6. REMOVE WORDPRESS DEFAULT STYLES THAT MIGHT INTERFERE
+add_action('wp_enqueue_scripts', 'remove_wp_default_styles', 20);
+function remove_wp_default_styles() {
+    // Remove block library CSS if not needed
+    // wp_dequeue_style('wp-block-library');
+
+    // Remove classic themes CSS
+    wp_dequeue_style('classic-theme-styles');
+
+    // Remove global styles
+    wp_dequeue_style('global-styles');
+}
+
+// 7. REMOVE WORDPRESS HEAD CLUTTER
+remove_action('wp_head', 'wp_generator');
+remove_action('wp_head', 'wlwmanifest_link');
+remove_action('wp_head', 'rsd_link');
+
+// 8. FOR SPECIFIC THEMES - ADD MORE AS NEEDED
+
+// Genesis Framework
+add_action('init', 'remove_genesis_header');
+function remove_genesis_header() {
+    if (function_exists('genesis')) {
+        remove_action('genesis_header', 'genesis_header_markup_open', 5);
+        remove_action('genesis_header', 'genesis_do_header');
+        remove_action('genesis_header', 'genesis_header_markup_close', 15);
+        remove_action('genesis_after_header', 'genesis_do_nav');
+    }
+}
+
+// Astra Theme
+add_action('init', 'remove_astra_header');
+function remove_astra_header() {
+    if (class_exists('Astra_Theme_Options')) {
+        remove_action('astra_header', 'astra_header_markup');
+        remove_action('astra_header', 'astra_masthead_get_menu_items');
+    }
+}
+
+// Twenty Twenty-One/Two/Three
+add_action('init', 'remove_twentytwenty_header');
+function remove_twentytwenty_header() {
+    if (wp_get_theme()->get('Name') === 'Twenty Twenty-One' ||
+        wp_get_theme()->get('Name') === 'Twenty Twenty-Two' ||
+        wp_get_theme()->get('Name') === 'Twenty Twenty-Three') {
+
+        remove_action('wp_body_open', 'twentytwentyone_skip_link', 5);
+        remove_action('wp_footer', 'twentytwentyone_dark_mode_script');
+    }
+}
+
+// 9. CLEAN UP WORDPRESS HEAD
+add_action('init', 'cleanup_wp_head');
+function cleanup_wp_head() {
+    // Remove unnecessary WordPress head elements
+    remove_action('wp_head', 'feed_links', 2);
+    remove_action('wp_head', 'feed_links_extra', 3);
+    remove_action('wp_head', 'adjacent_posts_rel_link_wp_head', 10, 0);
+    remove_action('wp_head', 'wp_shortlink_wp_head', 10, 0);
+}
+
+// 10. ENSURE CLEAN BODY CLASSES
+add_filter('body_class', 'remove_admin_body_classes');
+function remove_admin_body_classes($classes) {
+    // Remove admin-bar class
+    if (($key = array_search('admin-bar', $classes)) !== false) {
+        unset($classes[$key]);
+    }
+    return $classes;
+}
+
 ?>


### PR DESCRIPTION
## Summary
- disable admin bar and header elements in `functions.php`
- add cleanup for WordPress styles and theme specific hooks

## Testing
- `php -l assets/php/functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68686c6a3730833192d39a7f1bdd2a63