### PR TITLE
Enhance banner close functionality

### DIFF
--- a/header/banner/Javascript/index.html
+++ b/header/banner/Javascript/index.html
@@ -1,16 +1,28 @@
 // JavaScript snippet to auto-close the banner
 function closeBanner() {
     const banner = document.getElementById('workshopBanner');
+    if (!banner) return;
+    const body = document.body;
+    const height = banner.offsetHeight;
+
     banner.style.transition = 'transform 0.4s ease, opacity 0.4s ease';
     banner.style.transform = 'translateY(-100%)';
     banner.style.opacity = '0';
 
+    body.classList.add('banner-closed');
+    window.scrollBy({ top: -height, behavior: 'smooth' });
+
     setTimeout(() => {
         banner.style.display = 'none';
+        document.dispatchEvent(new CustomEvent('bannerClosed'));
     }, 400); // Matches the transition duration
+}
+
+function autoCloseBanner() {
+    setTimeout(closeBanner, 1000);
 }
 
 // Auto-collapse banner after page load
 window.addEventListener('load', () => {
-    setTimeout(closeBanner, 1000);
+    autoCloseBanner();
 });

--- a/header/banner/index.html
+++ b/header/banner/index.html
@@ -406,13 +406,25 @@
     <script>
         function closeBanner() {
             const banner = document.getElementById('workshopBanner');
+            if (!banner) return;
+            const body = document.body;
+            const height = banner.offsetHeight;
+
             banner.style.transition = 'transform 0.4s ease, opacity 0.4s ease';
             banner.style.transform = 'translateY(-100%)';
             banner.style.opacity = '0';
-            
+
+            body.classList.add('banner-closed');
+            window.scrollBy({ top: -height, behavior: 'smooth' });
+
             setTimeout(() => {
                 banner.style.display = 'none';
+                document.dispatchEvent(new CustomEvent('bannerClosed'));
             }, 400); // Matches the transition duration
+        }
+
+        function autoCloseBanner() {
+            setTimeout(closeBanner, 1000);
         }
 
         function registerWorkshop() {
@@ -433,7 +445,7 @@
                 banner.style.opacity = '1';
 
                 // Auto-collapse after 1 second on all devices
-                setTimeout(closeBanner, 1000);
+                autoCloseBanner();
             }, 100); // Short delay to ensure initial styles are applied before animating
         });
     </script>

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -403,13 +403,25 @@
     <script>
         function closeBanner() {
             const banner = document.getElementById('workshopBanner');
+            if (!banner) return;
+            const body = document.body;
+            const height = banner.offsetHeight;
+
             banner.style.transition = 'transform 0.4s ease, opacity 0.4s ease';
             banner.style.transform = 'translateY(-100%)';
             banner.style.opacity = '0';
-            
+
+            body.classList.add('banner-closed');
+            window.scrollBy({ top: -height, behavior: 'smooth' });
+
             setTimeout(() => {
                 banner.style.display = 'none';
+                document.dispatchEvent(new CustomEvent('bannerClosed'));
             }, 400); // Matches the transition duration
+        }
+
+        function autoCloseBanner() {
+            setTimeout(closeBanner, 1000);
         }
 
         function registerWorkshop() {
@@ -430,7 +442,7 @@
                 banner.style.opacity = '1';
 
                 // Auto-collapse after 1 second
-                setTimeout(closeBanner, 1000);
+                autoCloseBanner();
             }, 100); // Short delay to ensure initial styles are applied before animating
         });
     </script>


### PR DESCRIPTION
## Summary
- update header banner close function to add `banner-closed` class
- scroll page smoothly when closing
- dispatch a `bannerClosed` event
- automatically call the new handler after fade-in

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869c116dc848331b7f5f8b5132814eb