### PR TITLE
Fix portal card update

### DIFF
--- a/plugins/treasury-portal-access/includes/frontend-scripts.php
+++ b/plugins/treasury-portal-access/includes/frontend-scripts.php
@@ -111,21 +111,16 @@ if (empty($form_id)) {
          */
         updateUIAfterRestore: function() {
             document.querySelectorAll('.open-portal-modal, a[href="#openPortalModal"]').forEach(el => {
-                const newLink = document.createElement('a');
-                newLink.href = this.redirectUrl;
-                
-                // Copy classes from the original button for consistent styling.
-                newLink.className = el.className;
-                newLink.classList.remove('open-portal-modal');
-                newLink.textContent = 'View Portal';
-
-                // Try to replace the parent button block if it exists, otherwise replace the element itself.
-                const parentWrapper = el.closest('.wp-block-button');
-                if (parentWrapper) {
-                    parentWrapper.innerHTML = ''; // Clear the old button
-                    parentWrapper.appendChild(newLink);
+                if (el.tagName.toLowerCase() === 'a') {
+                    el.href = this.redirectUrl;
                 } else {
-                    el.parentNode.replaceChild(newLink, el);
+                    el.setAttribute('data-href', this.redirectUrl);
+                }
+
+                el.classList.remove('open-portal-modal');
+
+                if (el.textContent.trim() === 'Access Portal') {
+                    el.textContent = 'View Portal';
                 }
             });
             


### PR DESCRIPTION
## Summary
- keep the portal card markup intact when restoring access

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869c30597c883319e1bb85606963746