### PR TITLE
Fix mobile nav font color

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -3439,20 +3439,23 @@ body.banner-closed .workshop-banner {
 
 /* Mobile navigation fixes */
 @media (max-width: 992px) {
-    .rt-nav-link,
-    .rt-nav-link:link,
-    .rt-nav-link:visited,
-    .rt-nav-link:hover,
-    .rt-nav-link:active,
-    .rt-nav-link:focus {
+    /* Override highly specific desktop rule */
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link,
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link:link,
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link:visited,
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link:hover,
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link:active,
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link:focus {
         color: var(--dark-text) !important; /* Dark text on mobile light background */
     }
-    
-    .rt-nav-link.has-dropdown::after {
-        border-top-color: var(--dark-text) !important;
+
+    .rt-nav-container .rt-nav .rt-nav-item.active .rt-nav-link {
+        color: var(--dark-text) !important;
+        background: rgba(255, 255, 255, 0.1) !important;
     }
-    
-    .rt-nav-item.active .rt-nav-link.has-dropdown::after {
+
+    .rt-nav-container .rt-nav .rt-nav-item .rt-nav-link.has-dropdown::after,
+    .rt-nav-container .rt-nav .rt-nav-item.active .rt-nav-link.has-dropdown::after {
         border-top-color: var(--dark-text) !important;
     }
 }


### PR DESCRIPTION
## Summary
- ensure mobile nav links use dark text color by overriding highly specific desktop styles

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_686a5f3fc2088331b43f2216a40150ef