### PR TITLE
Fix portal card update

### DIFF
--- a/plugins/treasury-portal-access/includes/frontend-scripts.php
+++ b/plugins/treasury-portal-access/includes/frontend-scripts.php
@@ -107,26 +107,20 @@ if (empty($form_id)) {
         },
         
         /**
-         * Replaces "Access" buttons with "View Portal" links after a successful login.
+         * Update portal buttons/links once access is restored.
+         *
+         * Keeps the existing markup and text intact so the page doesn't flash
+         * between "Access" and "View" states on load.
          */
         updateUIAfterRestore: function() {
             document.querySelectorAll('.open-portal-modal, a[href="#openPortalModal"]').forEach(el => {
-                const newLink = document.createElement('a');
-                newLink.href = this.redirectUrl;
-                
-                // Copy classes from the original button for consistent styling.
-                newLink.className = el.className;
-                newLink.classList.remove('open-portal-modal');
-                newLink.textContent = 'View Portal';
-
-                // Try to replace the parent button block if it exists, otherwise replace the element itself.
-                const parentWrapper = el.closest('.wp-block-button');
-                if (parentWrapper) {
-                    parentWrapper.innerHTML = ''; // Clear the old button
-                    parentWrapper.appendChild(newLink);
+                if (el.tagName.toLowerCase() === 'a') {
+                    el.href = this.redirectUrl;
                 } else {
-                    el.parentNode.replaceChild(newLink, el);
+                    el.setAttribute('data-href', this.redirectUrl);
                 }
+
+                el.classList.remove('open-portal-modal');
             });
             
             // If a protected content block was showing an access message, reload the page to show the actual content.


### PR DESCRIPTION
## Summary
- keep the portal card markup intact when restoring access
- keep button text stable while updating link

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869c30597c883319e1bb85606963746