### PR TITLE
Refine submenu font size

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1441,6 +1441,7 @@
     background: none !important;
     border-radius: 8px;
     display: block;
+    font-size: 1.5rem !important;
 }
 
 .rt-main-menu-link:hover {
@@ -1510,7 +1511,7 @@
 }
 
 .rt-about-menu .rt-main-menu-link {
-    font-size: 1.2rem !important;
+    font-size: 1.5rem !important;
     text-align: center;
     padding: 1rem !important;
 }
@@ -1881,6 +1882,7 @@
         display: block !important;
         margin-bottom: 0.5rem !important;
         border: 1px solid rgba(199, 125, 255, 0.2) !important;
+        font-size: 1.5rem !important;
     }
     
     .rt-main-menu-link:hover {

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -41,7 +41,7 @@ function add_my_custom_header_html() {
                                 <div class="rt-main-menu-column rt-topics-column">
                                     <h3>Topics</h3>
                                     <div class="rt-main-menu-links">
-                                        <a href="#openPortalModal" class="rt-main-menu-link">Treasury Tech Stack</a>
+                                        <a href="#openPortalModal" class="rt-main-menu-link">Treasury Tech Portal</a>
                                         <a href="https://realtreasury.com/errnot/" class="rt-main-menu-link">ERR NOT Method</a>
                                         <a href="https://realtreasury.com/treasury-tech-market/" class="rt-main-menu-link">Treasury Tech Market</a>
                                         <a href="https://realtreasury.com/posts/" class="rt-main-menu-link">All Insights</a>


### PR DESCRIPTION
## Summary
- dial back submenu font size to 1.5rem
- match the About dropdown link styling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686aefad17ac8331a401e34c8bc72c47