### PR TITLE
Add explore image to Insights dropdown

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1564,6 +1564,17 @@
     text-decoration: none;
 }
 
+/* Explore Dropdown Image */
+.rt-explore-image {
+    display: block;
+    width: 100%;
+    max-width: 340px;
+    margin: 1rem auto;
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(114, 22, 244, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    border: 1px solid rgba(114, 22, 244, 0.2);
+}
+
 /* Insights Widget */
 .rt-insights-widget {
     width: 100%;

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -37,6 +37,10 @@ function add_my_custom_header_html() {
                                        class="rt-book-meeting">
                                         Save My Seat<br>for the Live Session
                                     </a>
+                                    <img class="rt-explore-image"
+                                         src="https://realtreasury.com/wp-content/uploads/2025/07/treasury-tech-market-clean-06-2025.png"
+                                         alt="Treasury Tech Market"
+                                         loading="lazy">
                                 </div>
                                 <div class="rt-main-menu-column rt-topics-column">
                                     <h3>Topics</h3>


### PR DESCRIPTION
## Summary
- show Treasury Tech Market preview under the Explore column
- style new Explore dropdown image so it's consistent with Latest Insights widget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686af0290c788331ada433049bce36c8