### PR TITLE
Fix portal access checkbox style

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -204,7 +204,7 @@
 }
 
 /* Input fields */
-.form-control,
+.form-control:not([type="checkbox"]),
 .wpcf7-form-control:not(.wpcf7-submit):not([type="checkbox"]) {
     width: 100% !important;
     padding: 12px 16px !important;
@@ -258,8 +258,8 @@
 
 .checkbox-row input[type=checkbox] {
     position: relative !important;
-    width: 20px !important;
-    height: 20px !important;
+    width: 16px !important;
+    height: 16px !important;
     margin: 0 !important;
     flex-shrink: 0 !important;
     margin-top: 2px !important;


### PR DESCRIPTION
## Summary
- avoid overriding checkboxes with generic form-control rule
- shrink checkbox sizes for portal access form

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b00f975288331aedbd11f7c3e3a1c