### PR TITLE
Fix tagline on errnot page

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -542,7 +542,7 @@
                 <div class="bg-white rounded-2xl p-8 border border-purple-200 shadow-md">
                     <div class="text-4xl mb-4">🎥</div>
                     <h3 class="text-xl font-bold mb-4">Explore the Portal</h3>
-                    <p class="text-gray-600 mb-6 text-sm">Access 27+ demo videos and vendor info with powerful filters and comparisons</p>
+                    <p class="text-gray-600 mb-6 text-sm">Access and compare 27+ vendors and videos</p>
                     <button class="open-video-modal w-full text-center block cta-secondary">
                         Access Tech Portal
                     </button>


### PR DESCRIPTION
## Summary
- tweak copy on the errnot portal access banner

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686b1bbe43c08331917fa9f943e9f776