### PR TITLE
Hide workshop banner on small screens

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1950,6 +1950,7 @@ body.banner-closed .workshop-banner {
 /* Mobile banner adjustments */
 @media (max-width: 768px) {
     .workshop-banner {
+        display: none !important;
         min-height: 60px !important;
     }
     
@@ -1973,6 +1974,7 @@ body.banner-closed .workshop-banner {
 
 @media (max-width: 480px) {
     .workshop-banner {
+        display: none !important;
         min-height: 50px !important;
     }
     


### PR DESCRIPTION
## Summary
- hide `.workshop-banner` for max-width 768px and 480px breakpoints
- keep existing spacing adjustments for nav container and body

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b22d834c48331a46872f36d142ae1