### PR TITLE
Fix CF7 checkbox styles

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -2480,7 +2480,7 @@ body.banner-closed .workshop-banner {
 }
 
 /* =================================================================== */
-/* CONTACT FORM 7 CHECKBOX FIX - CORRECTED */
+/* CONTACT FORM 7 CHECKBOX FIX - FINAL VERSION */
 /* =================================================================== */
 
 /* Reset the checkbox container */
@@ -2505,21 +2505,25 @@ body.banner-closed .workshop-banner {
     width: 100% !important;
 }
 
-/* Target the CF7 checkbox wrapper span */
+/* Target the CF7 checkbox wrapper span - DON'T let it stretch */
 .portal-access-form .wpcf7-checkbox {
     display: flex !important;
     align-items: flex-start !important;
     margin: 0 !important;
     padding: 0 !important;
+    width: auto !important;
+    flex-shrink: 0 !important;
 }
 
-/* Target the CF7 checkbox label span that contains the input */
+/* Target the CF7 checkbox list item wrapper - keep it compact */
 .portal-access-form .wpcf7-checkbox .wpcf7-list-item {
     margin: 0 !important;
     padding: 0 !important;
     display: flex !important;
-    align-items: flex-start !important;
-    gap: 8px !important;
+    align-items: center !important;
+    gap: 0 !important;
+    width: auto !important;
+    flex-shrink: 0 !important;
 }
 
 /* Style the actual checkbox input */
@@ -2533,7 +2537,6 @@ body.banner-closed .workshop-banner {
     border-radius: 4px !important;
     background: #ffffff !important;
     margin: 0 !important;
-    margin-top: 2px !important;
     flex-shrink: 0 !important;
     cursor: pointer !important;
     position: relative !important;
@@ -2571,7 +2574,6 @@ body.banner-closed .workshop-banner {
     cursor: pointer !important;
     font-weight: 400 !important;
     flex: 1 !important;
-    margin-left: 8px !important;
 }
 
 /* Ensure links in the label work */


### PR DESCRIPTION
## Summary
- update Contact Form 7 checkbox styles so wrapper doesn't stretch

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b2731c2908331890322ff52fdb478