### PR TITLE
Fix cookie banner position

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -549,7 +549,6 @@ body.modal-open {
             z-index: 99996 !important;
             border-top: 1px solid hsla(0, 0%, 100%, .2);
             box-shadow: 0 -4px 20px rgba(0, 0, 0, .3), inset 0 1px 0 hsla(0, 0%, 100%, .1);
-            position: relative;
             overflow: hidden;
         }
         .cookie-banner:before {


### PR DESCRIPTION
## Summary
- ensure cookie banner stays fixed at bottom by removing `position: relative`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b4fb059cc8331b0134c783eec3625