### PR TITLE
Update icon color for active toggles

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -1328,7 +1328,7 @@
 
         .external-menu-toggle.active .icon {
             background: rgba(114,22,244,0.9);
-            color: #fff;
+            color: #7216f4;
         }
 
         .external-menu-toggle.active .icon::before {
@@ -1382,7 +1382,7 @@
 
         .external-shortlist-toggle.active .icon {
             background: rgba(114,22,244,0.9);
-            color: #fff;
+            color: #7216f4;
         }
 
         .external-shortlist-toggle.active .icon::before {


### PR DESCRIPTION
## Summary
- keep `.external-menu-toggle` and `.external-shortlist-toggle` icons purple when active

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b5334009c833190b6bcc4de5802f1