### PR TITLE
Fix logo display and card layout

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -508,9 +508,9 @@
 
         .treasury-portal .tool-header {
             display: flex;
-            align-items: center;
-            justify-content: space-between;
-            margin-bottom: 10px;
+            align-items: flex-start;
+            gap: 12px;
+            margin-bottom: 6px;
         }
 
         .treasury-portal .tool-meta {
@@ -523,22 +523,28 @@
             display: flex;
             flex-direction: column;
             flex-grow: 1;
+            gap: 2px;
         }
 
         .treasury-portal .tool-name {
             font-size: 1.2rem;
             font-weight: 700;
             color: #281345;
-            margin-bottom: 2px;
+            margin-bottom: 0;
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             line-height: 1.2;
             display: flex;
             align-items: center;
+            flex-wrap: wrap;
             gap: 8px;
             position: relative;
             z-index: 1;
             text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
             letter-spacing: 0.5px;
+        }
+
+        .treasury-portal .tool-name-title {
+            margin-right: 0;
         }
         .treasury-portal .tool-logo {
             width: 100px;
@@ -553,7 +559,7 @@
             height: 100px;
             object-fit: contain;
             display: block;
-            margin: 0 auto 20px;
+            margin: 0;
         }
 
         .treasury-portal .tool-logo-inline {
@@ -582,12 +588,38 @@
             border-radius: 4px;
             border: 1px solid rgba(99, 102, 241, 0.2);
             transition: all 0.3s ease;
+            margin-right: 16px;
         }
 
         .treasury-portal .tool-card:hover .video-indicator {
             opacity: 1;
             background: rgba(99, 102, 241, 0.2);
             border-color: rgba(99, 102, 241, 0.4);
+        }
+
+        .treasury-portal .tool-actions {
+            margin-left: auto;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .treasury-portal .tool-website-link {
+            display: inline-block;
+            text-align: center;
+            background: linear-gradient(135deg, #7216f4, #8f47f6);
+            color: #ffffff;
+            text-decoration: none;
+            border-radius: 6px;
+            font-weight: 600;
+            font-size: 0.75rem;
+            padding: 4px 8px;
+            line-height: 1.1;
+        }
+
+        .treasury-portal .tool-website-link:hover {
+            background: linear-gradient(135deg, #8f47f6, #7216f4);
+            text-decoration: none;
         }
 
         .treasury-portal .tool-type {
@@ -1560,6 +1592,11 @@
         }
 
         .treasury-portal .shortlist-card-title-wrapper { display:flex; align-items:center; gap:4px; }
+        .treasury-portal .shortlist-logo {
+            width: 36px;
+            height: 36px;
+            object-fit: contain;
+        }
         .treasury-portal .shortlist-card-title { font-size:0.9rem; font-weight:600; color:#281345; }
         .treasury-portal .shortlist-card-link {
             display:inline-flex;

--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -1489,8 +1489,9 @@ document.addEventListener('DOMContentLoaded', () => {
                         div.innerHTML = `
                             <div class="shortlist-card-header">
                                 <div class="shortlist-card-title-wrapper">
+                                    ${item.tool.logoUrl ? `<img class="shortlist-logo" src="${item.tool.logoUrl}" alt="${item.tool.name} logo">` : ''}
                                     <span class="shortlist-card-title">${item.tool.name}</span>
-                                    ${item.tool.websiteUrl ? `<a class="shortlist-card-link" href="${item.tool.websiteUrl}" target="_blank" rel="noopener noreferrer" title="Visit website">↗</a>` : ''}
+                                    ${item.tool.websiteUrl ? `<a class="shortlist-card-link" href="${item.tool.websiteUrl}" target="_blank" rel="noopener noreferrer">Visit<br>Website</a>` : ''}
                                 </div>
                                 <div class="shortlist-card-buttons">
                                     <button class="move-up" data-name="${item.tool.name}" aria-label="Move up">▲</button>


### PR DESCRIPTION
## Summary
- tweak layout for vendor tool cards
- ensure modal logos and shortlist logos display correctly

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bd648c3148331868bd1d7265fa80d