### PR TITLE
Fix tool card name wrapping

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -547,8 +547,8 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
             line-height: 1.2;
             display: flex;
-            align-items: center;
-            flex-wrap: wrap;
+            align-items: flex-start;
+            flex-wrap: nowrap;
             gap: 8px;
             position: relative;
             z-index: 1;
@@ -557,6 +557,12 @@
         }
 
         .treasury-portal .tool-name-title {
+            flex: 1;
+            min-width: 0;
+            word-break: break-word;
+            hyphens: auto;
+            line-height: 1.3;
+            max-width: 60%;
             margin-right: 0;
         }
         .treasury-portal .tool-logo {
@@ -580,6 +586,7 @@
             height: 75px;
             object-fit: contain;
             margin-top: 0;
+            flex-shrink: 0;
         }
 
         .treasury-portal .tool-logo-inline.no-video {
@@ -615,6 +622,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
+            flex-shrink: 0;
         }
 
         .treasury-portal .tool-website-link {


### PR DESCRIPTION
## Summary
- adjust `.tool-name` layout to prevent wrapping
- make long tool titles wrap cleanly
- ensure logo and actions don't shrink

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bdb670d888331a682497c011c4453