### PR TITLE
Move modal logo to the right of title for better visual hierarchy

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -774,13 +774,36 @@
 
         /* Modal Header */
         .treasury-portal .modal-header {
-            padding: 12px 20px; /* Reduced padding */
+            padding: 12px 20px;
             border-bottom: 1px solid #e5e7eb;
             display: flex;
             justify-content: space-between;
             align-items: center;
             flex-shrink: 0;
-            gap: 12px; /* Reduced gap */
+            gap: 12px;
+        }
+
+        /* Group modal title and logo together */
+        .treasury-portal .modal-title-group {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex: 1;
+        }
+
+        /* Ensure modal title doesn't have conflicting margins */
+        .treasury-portal .modal-title-group .modal-title {
+            margin: 0;
+            flex-shrink: 0;
+        }
+
+        /* Style the logo within the title group */
+        .treasury-portal .modal-title-group .modal-tool-logo {
+            width: 40px;
+            height: 40px;
+            object-fit: contain;
+            display: block;
+            flex-shrink: 0;
         }
 
         .treasury-portal .modal-title {

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -241,8 +241,10 @@ if (!defined("ABSPATH")) exit;
         <div class="ttp-modal" id="toolModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
             <div class="ttp-modal-content" tabindex="-1">
                 <div class="modal-header">
-                    <img id="modalToolLogo" class="modal-tool-logo" alt="">
-                    <h3 class="modal-title" id="modalTitle"></h3>
+                    <div class="modal-title-group">
+                        <h3 class="modal-title" id="modalTitle"></h3>
+                        <img id="modalToolLogo" class="modal-tool-logo" alt="">
+                    </div>
                     <div class="modal-header-actions">
                         <a id="modalWebsiteLink" href="#" target="_blank" rel="noopener noreferrer" class="website-link--modal" style="display: none;">Website</a>
                         <button class="modal-close" id="modalClose">×</button>


### PR DESCRIPTION
## Summary
- group modal title with its logo in `toolModal`
- style `.modal-title-group` so the logo sits after the title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be2916524833184f20729f3a1eb1b