### PR TITLE
Fix video display sizing in vendor tool modal popups

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -869,6 +869,16 @@
             margin-bottom: 12px; /* Reduced from 20px */
         }
 
+        .treasury-portal .video-container iframe,
+        .treasury-portal .video-container video {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+        }
+
         /* Modal logo - smaller */
         .treasury-portal .modal-tool-logo {
             width: 60px; /* Reduced from 100px */


### PR DESCRIPTION
## Summary
- ensure vendor tool modal popups render iframe and video content correctly

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686be3fec16083319fd4ca034a3e7427