### PR TITLE
Improve vendor logo sizing and spacing in Treasury Tech Portal

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -573,32 +573,35 @@
             flex-shrink: 0;
         }
 
-        .treasury-portal .modal-tool-logo {
-            width: 100px;
-            height: 100px;
-            object-fit: contain;
-            display: block;
-            margin: 0;
-        }
+.treasury-portal .modal-tool-logo {
+    width: 120px;
+    height: 120px;
+    object-fit: contain;
+    display: block;
+    margin: 0;
+    margin-right: 20px;
+}
 
-        .treasury-portal .tool-logo-inline {
-            width: 60px;
-            height: 60px;
-            object-fit: contain;
-            margin-top: 0;
-            flex-shrink: 0;
-        }
+.treasury-portal .tool-logo-inline {
+    width: 80px;
+    height: 80px;
+    object-fit: contain;
+    margin-top: 0;
+    margin-left: 12px;
+    margin-right: 16px;
+    flex-shrink: 0;
+}
 
         .treasury-portal .tool-logo-inline.no-video {
             margin-left: 8px;
         }
 
-        @media (max-width: 768px) {
-            .treasury-portal .tool-logo-inline {
-                width: 45px;
-                height: 45px;
-            }
-        }
+@media (max-width: 768px) {
+    .treasury-portal .tool-logo-inline {
+        width: 65px;
+        height: 65px;
+    }
+}
 
         .treasury-portal .video-indicator {
             font-size: 0.8rem;
@@ -902,14 +905,15 @@
             border: none;
         }
 
-        /* Modal logo - smaller */
-        .treasury-portal .modal-tool-logo {
-            width: 60px; /* Reduced from 100px */
-            height: 60px;
-            object-fit: contain;
-            display: block;
-            margin: 0;
-        }
+/* Modal logo - updated */
+.treasury-portal .modal-tool-logo {
+    width: 120px;
+    height: 120px;
+    object-fit: contain;
+    display: block;
+    margin: 0;
+    margin-right: 20px;
+}
 
         /* Website link - more compact */
         .treasury-portal .website-link--modal {
@@ -973,8 +977,8 @@
             }
 
             .treasury-portal .modal-tool-logo {
-                width: 50px;
-                height: 50px;
+                width: 100px;
+                height: 100px;
             }
         }
 


### PR DESCRIPTION
## Summary
- enlarge vendor logos in tool cards with better spacing
- increase modal logo size and add right margin
- adjust responsive sizes for mobile viewports

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686be53dae3083319921b8c4e184a588