### PR TITLE
Make logos clickable

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -921,7 +921,7 @@
 }
 
         /* Website link - more compact */
-        .treasury-portal .website-link--modal {
+.treasury-portal .website-link--modal {
             background: linear-gradient(135deg, #7216f4, #8f47f6);
             color: #ffffff;
             text-shadow: 0 1px 2px rgba(0,0,0,0.2);
@@ -935,11 +935,44 @@
             align-items: center;
             justify-content: center;
             box-shadow: 0 4px 15px -5px rgba(114, 22, 244, 0.5);
-            border: none;
-        }
+        border: none;
+}
 
-        /* Modal Close Button - smaller */
-        .treasury-portal .modal-close {
+/* Clickable logo links */
+.treasury-portal .tool-logo-link {
+    display: inline-block;
+    text-decoration: none;
+    transition: opacity 0.3s ease;
+}
+
+.treasury-portal .tool-logo-link:hover {
+    opacity: 0.8;
+}
+
+.treasury-portal .modal-logo-link {
+    display: inline-block;
+    text-decoration: none;
+    transition: opacity 0.3s ease;
+}
+
+.treasury-portal .modal-logo-link:hover {
+    opacity: 0.8;
+}
+
+/* Ensure logo images maintain their styling within links */
+.treasury-portal .tool-logo-link .tool-logo-inline,
+.treasury-portal .modal-logo-link .modal-tool-logo {
+    display: block;
+    transition: transform 0.3s ease;
+}
+
+.treasury-portal .tool-logo-link:hover .tool-logo-inline,
+.treasury-portal .modal-logo-link:hover .modal-tool-logo {
+    transform: scale(1.05);
+}
+
+/* Modal Close Button - smaller */
+.treasury-portal .modal-close {
             background: #f3f4f6;
             border: none;
             color: #6b7280;

--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -764,9 +764,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 if (modalLogo) {
                     if (tool.logoUrl) {
-                        modalLogo.src = tool.logoUrl;
-                        modalLogo.alt = `${tool.name} logo`;
-                        modalLogo.style.display = 'block';
+                        if (tool.websiteUrl) {
+                            modalLogo.outerHTML = `<a href="${tool.websiteUrl}" target="_blank" rel="noopener noreferrer" class="modal-logo-link"><img id="modalToolLogo" class="modal-tool-logo" src="${tool.logoUrl}" alt="${tool.name} logo"></a>`;
+                        } else {
+                            modalLogo.src = tool.logoUrl;
+                            modalLogo.alt = `${tool.name} logo`;
+                            modalLogo.style.display = 'block';
+                        }
                     } else {
                         modalLogo.style.display = 'none';
                     }
@@ -1076,9 +1080,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                         <span class="tool-name-title">${tool.name}</span>
                                         ${tool.videoUrl ? '<span class="video-indicator">🎥</span>' : ''}
                                     </div>
-                                    ${tool.logoUrl ? `<img class="tool-logo-inline${tool.videoUrl ? '' : ' no-video'}" src="${tool.logoUrl}" alt="${tool.name} logo">` : ''}
+                                    ${tool.logoUrl ? `<a href="${tool.websiteUrl || '#'}" target="_blank" rel="noopener noreferrer" class="tool-logo-link" ${!tool.websiteUrl ? 'style="pointer-events: none; cursor: default;"' : ''}><img class="tool-logo-inline${tool.videoUrl ? '' : ' no-video'}" src="${tool.logoUrl}" alt="${tool.name} logo"></a>` : ''}
                                     <div class="tool-actions">
-                                        ${tool.websiteUrl ? `<a class="tool-website-link" href="${tool.websiteUrl}" target="_blank" rel="noopener noreferrer">Website</a>` : ''}
                                         <div class="tool-icon">${iconMap[tool.category]}</div>
                                     </div>
                                 </div>
@@ -1139,6 +1142,16 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                         this.touchDragTool = null;
                     });
+                }
+
+                // Prevent logo click from triggering card modal when logo has a valid link
+                if (tool.websiteUrl) {
+                    const logoLink = card.querySelector('.tool-logo-link');
+                    if (logoLink) {
+                        logoLink.addEventListener('click', (e) => {
+                            e.stopPropagation();
+                        });
+                    }
                 }
 
                 return card;


### PR DESCRIPTION
## Summary
- convert tool card logos to links
- remove website button from tool card
- wrap modal logo in link when website available
- add hoverable logo link styles
- block card modal open when clicking logo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686be9445d3c8331a29782267257c854