### PR TITLE
Reduce minimized banner height

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1948,11 +1948,15 @@ body {
 
 /* Add missing body padding for minimized banner state */
 body.banner-minimized {
-    padding-top: 150px !important; /* 70px banner + 80px nav */
+    padding-top: 140px !important; /* 60px banner + 80px nav */
 }
 
 body.banner-minimized .rt-nav-container {
-    top: 70px !important; /* Position nav below minimized banner */
+    top: 60px !important; /* Position nav below minimized banner */
+}
+
+body.banner-minimized .rt-dropdown {
+    top: 140px !important; /* Dropdown appears below nav */
 }
 
 body.banner-closed .rt-nav-container {

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -93,8 +93,8 @@ body {
 
 /* Minimized state - keep key info visible */
 .workshop-banner.minimized {
-    min-height: 70px !important;
-    padding: 12px 40px !important;
+    min-height: 60px !important;
+    padding: 10px 40px !important;
     cursor: pointer;
     background: linear-gradient(135deg,
         rgba(114, 22, 244, 0.9),
@@ -357,11 +357,15 @@ body {
 /* When banner is minimized, adjust navigation */
 .workshop-banner.minimized ~ .rt-nav-container,
 body.banner-minimized .rt-nav-container {
-    top: 20px !important;
+    top: 60px !important;
 }
 
 body.banner-minimized {
-    padding-top: 100px !important; /* 20px banner + 80px nav */
+    padding-top: 140px !important; /* 60px banner + 80px nav */
+}
+
+body.banner-minimized .rt-dropdown {
+    top: 140px !important;
 }
 
 /* Hide banner entirely on mobile */


### PR DESCRIPTION
## Summary
- shorten the minimized workshop banner to 60px
- adjust nav and dropdown positioning when the banner is minimized

## Testing
- `npm run build` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_686bef4adb248331a1b883af2ff7feec