### PR TITLE
Fix banner layout for responsive widths

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1378,7 +1378,7 @@ body.modal-open {
     top: 80px;
     left: 0;
     right: 0;
-    width: 100vw;
+    width: 100%;
     background: linear-gradient(135deg, hsla(0, 0%, 100%, .85), hsla(0, 0%, 97%, .9)) !important;
     backdrop-filter: blur(20px) saturate(130%) !important;
     -webkit-backdrop-filter: blur(20px) saturate(130%) !important;
@@ -1931,7 +1931,7 @@ body.banner-minimized .content-area {
     left: 0 !important;
     right: 0 !important;
     z-index: 100000 !important;
-    width: 100vw !important;
+    width: 100% !important;
     min-height: 80px !important;
     transition: transform 0.4s ease, opacity 0.4s ease !important;
 }

--- a/header/banner/index.html
+++ b/header/banner/index.html
@@ -17,17 +17,16 @@
             padding: 0;
             margin: 0;
             min-height: 100vh;
-            /* FIX: overflow-x: hidden prevents a horizontal scrollbar from appearing
-               when an element (like the banner using 100vw) is slightly wider than the viewport.
-               This stops the page content from "jumping" or resizing when the banner is closed. */
+            /* Prevent horizontal scrollbars when the banner spans the full viewport
+               width. This stops the page content from "jumping" or resizing when
+               the banner is closed. */
             overflow-x: hidden;
         }
 
         .workshop-banner {
-            /* FIX: Using 100vw makes the banner truly full-width, edge-to-edge.
-               Combined with `overflow-x: hidden` on the body, this provides the desired
-               visuals without causing a layout shift on close. */
-            width: 100vw;
+            /* The banner spans the full viewport width.
+               With `overflow-x: hidden` on the body, this prevents layout shifts when closing. */
+            width: 100%;
             margin: 0;
             margin-top: 0 !important;
             background: linear-gradient(135deg, 

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -23,7 +23,7 @@ body {
 }
 
 .workshop-banner {
-    width: 100vw;
+    width: 100%;
     margin: 0;
     background: linear-gradient(135deg, 
         rgba(255, 255, 255, 0.25), 
@@ -147,7 +147,7 @@ body {
     white-space: nowrap !important;
     overflow: hidden !important;
     text-overflow: ellipsis !important;
-    max-width: 380px !important;
+    max-width: clamp(150px, 50vw, 380px) !important;
 }
 
 .workshop-banner.minimized .banner-cta {


### PR DESCRIPTION
## Summary
- update banner HTML to remove `100vw` usage
- keep nav dropdown and banner widths responsive in shared CSS
- tweak minimized banner subtitle width for flexible layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bf6c329ac8331bfbf12b041b9aea2