### PR TITLE
Remove banner navigation click

### DIFF
--- a/header/banner/index.html
+++ b/header/banner/index.html
@@ -321,7 +321,7 @@
     </style>
 </head>
 <body>
-    <div class="workshop-banner" id="workshopBanner" onclick="navigateWorkshop(event)">
+    <div class="workshop-banner" id="workshopBanner">
         <button class="close-btn" onclick="closeBanner()" aria-label="Close banner">&times;</button>
         
         <div class="banner-content">
@@ -360,13 +360,7 @@
             window.open('https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration', '_blank');
         }
 
-        function navigateWorkshop(event) {
-            // Ignore clicks on the close button or Register link
-            if (event.target.closest('.close-btn') || event.target.closest('.banner-cta')) {
-                return;
-            }
-            window.location.href = 'https://realtreasury.com/tech-selection-workshop/';
-        }
+
 
         function isMobileDevice() {
             const ua = navigator.userAgent || navigator.vendor || window.opera;

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -431,7 +431,7 @@ body.banner-minimized .rt-dropdown {
 </style>
 </head>
 <body>
-    <div class="workshop-banner" id="workshopBanner" onclick="navigateWorkshop(event)">
+    <div class="workshop-banner" id="workshopBanner">
         <button class="close-btn" onclick="closeBanner(event)" aria-label="Close banner">&times;</button>
         
         <div class="banner-content">
@@ -500,13 +500,7 @@ function registerWorkshop(event) {
     window.open('https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration', '_blank');
 }
 
-function navigateWorkshop(event) {
-    // Ignore clicks on the close button or Register link
-    if (event.target.closest('.close-btn') || event.target.closest('.banner-cta')) {
-        return;
-    }
-    window.location.href = 'https://realtreasury.com/tech-selection-workshop/';
-}
+
 
 function isMobileDevice() {
     return window.innerWidth <= 768 || /android|iphone|ipad|ipod|iemobile|blackberry|bada/i.test(


### PR DESCRIPTION
## Summary
- stop navigating to the workshop page when the top banner is clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c11e82eec8331ba93392ed0d69b94