### PR TITLE
Update vendor logo links

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -652,24 +652,6 @@
             flex-shrink: 0;
         }
 
-        .treasury-portal .tool-website-link {
-            display: inline-block;
-            text-align: center;
-            background: linear-gradient(135deg, #7216f4, #8f47f6);
-            color: #ffffff;
-            text-decoration: none;
-            border-radius: 6px;
-            font-weight: 600;
-            font-size: 0.75rem;
-            padding: 4px 8px;
-            line-height: 1.1;
-        }
-
-        .treasury-portal .tool-website-link:hover {
-            background: linear-gradient(135deg, #8f47f6, #7216f4);
-            text-decoration: none;
-        }
-
         .treasury-portal .tool-type {
             font-size: 0.8rem;
             color: #7e7e7e;

--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.min.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.min.js
@@ -22,9 +22,8 @@ let EMBED_ORIGIN="https://realtreasury.com",treasuryTechPortal,portalRoot=docume
                                         <span class="tool-name-title">${t.name}</span>
                                         ${t.videoUrl?'<span class="video-indicator">🎥</span>':""}
                                     </div>
-                                    ${t.logoUrl?`<img class="tool-logo-inline${t.videoUrl?"":" no-video"}" src="${t.logoUrl}" alt="${t.name} logo">`:""}
+                                    ${t.logoUrl?`<a href="${t.websiteUrl||'#'}" target="_blank" rel="noopener noreferrer" class="tool-logo-link" ${t.websiteUrl?"":"style=\"pointer-events: none; cursor: default;\""}><img class="tool-logo-inline${t.videoUrl?"":" no-video"}" src="${t.logoUrl}" alt="${t.name} logo"></a>`:""}
                                     <div class="tool-actions">
-                                        ${t.websiteUrl?`<a class="tool-website-link" href="${t.websiteUrl}" target="_blank" rel="noopener noreferrer">Website</a>`:""}
                                         <div class="tool-icon">${{TRMS:"🏢",CASH:"💰",LITE:"⚡"}[t.category]}</div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- link vendor logos directly to their websites
- drop unused card website link styles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c13d8984c83319e6a8bd4e7ce5767