### PR TITLE
Adjust modal header offset

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -2828,43 +2828,40 @@ body.modal-open.shortlist-menu-open .treasury-portal .shortlist-menu {
 /* =================================================================== */
 
 /* Keep full-screen overlay but push content down below header */
+/*
 .portal-access-modal .portal-access-form,
 .modal-content,
 .tpa-modal-content,
 .treasury-portal .ttp-modal-content {
-    margin-top: 180px !important; /* Push below full header (160px + 20px breathing room) */
-    max-height: calc(100vh - 200px) !important; /* Ensure it fits in remaining space */
+    margin-top: 180px !important;
+    max-height: calc(100vh - 200px) !important;
 }
 
-/* When banner is minimized */
 body.banner-minimized .portal-access-modal .portal-access-form,
 body.banner-minimized .modal-content,
 body.banner-minimized .tpa-modal-content,
 body.banner-minimized .treasury-portal .ttp-modal-content {
-    margin-top: 160px !important; /* Push below minimized header (140px + 20px breathing room) */
+    margin-top: 160px !important;
     max-height: calc(100vh - 180px) !important;
 }
 
-/* When banner is completely closed */
 body.banner-closed .portal-access-modal .portal-access-form,
 body.banner-closed .modal-content,
 body.banner-closed .tpa-modal-content,
 body.banner-closed .treasury-portal .ttp-modal-content {
-    margin-top: 100px !important; /* Push below nav only (80px + 20px breathing room) */
+    margin-top: 100px !important;
     max-height: calc(100vh - 120px) !important;
 }
 
-/* Mobile adjustments */
 @media (max-width: 768px) {
     .portal-access-modal .portal-access-form,
     .modal-content,
     .tpa-modal-content,
     .treasury-portal .ttp-modal-content {
-        margin-top: 90px !important; /* Push below mobile nav (70px + 20px breathing room) */
+        margin-top: 90px !important;
         max-height: calc(100vh - 110px) !important;
     }
-    
-    /* No banner state changes needed on mobile since banner is hidden */
+
     body.banner-minimized .portal-access-modal .portal-access-form,
     body.banner-minimized .modal-content,
     body.banner-minimized .tpa-modal-content,
@@ -2875,6 +2872,66 @@ body.banner-closed .treasury-portal .ttp-modal-content {
     body.banner-closed .treasury-portal .ttp-modal-content {
         margin-top: 90px !important;
         max-height: calc(100vh - 110px) !important;
+    }
+}
+*/
+
+/* Updated modal offset using padding instead of margin */
+.portal-access-modal,
+.modal,
+.tpa-modal,
+.treasury-portal .ttp-modal {
+    padding-top: 160px !important;
+}
+
+body.banner-minimized .portal-access-modal,
+body.banner-minimized .modal,
+body.banner-minimized .tpa-modal,
+body.banner-minimized .treasury-portal .ttp-modal {
+    padding-top: 140px !important;
+}
+
+body.banner-closed .portal-access-modal,
+body.banner-closed .modal,
+body.banner-closed .tpa-modal,
+body.banner-closed .treasury-portal .ttp-modal {
+    padding-top: 80px !important;
+}
+
+.portal-access-modal .portal-access-form,
+.modal-content,
+.tpa-modal-content,
+.treasury-portal .ttp-modal-content {
+    max-height: calc(100vh - 160px - 40px) !important;
+}
+
+body.banner-minimized .portal-access-modal .portal-access-form,
+body.banner-minimized .modal-content,
+body.banner-minimized .tpa-modal-content,
+body.banner-minimized .treasury-portal .ttp-modal-content {
+    max-height: calc(100vh - 140px - 40px) !important;
+}
+
+body.banner-closed .portal-access-modal .portal-access-form,
+body.banner-closed .modal-content,
+body.banner-closed .tpa-modal-content,
+body.banner-closed .treasury-portal .ttp-modal-content {
+    max-height: calc(100vh - 80px - 40px) !important;
+}
+
+@media (max-width: 768px) {
+    .portal-access-modal,
+    .modal,
+    .tpa-modal,
+    .treasury-portal .ttp-modal {
+        padding-top: 70px !important;
+    }
+
+    .portal-access-modal .portal-access-form,
+    .modal-content,
+    .tpa-modal-content,
+    .treasury-portal .ttp-modal-content {
+        max-height: calc(100vh - 70px - 40px) !important;
     }
 }
 


### PR DESCRIPTION
## Summary
- comment old modal margin rules
- pad modals from the top so content sits below the header
- set matching max-height calculations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c1eacadf88331afe94a5f26ab63cf