### PR TITLE
Add Treasury logo carousel widget

### DIFF
--- a/widgets/treasury-logo-carousel/README.md
+++ b/widgets/treasury-logo-carousel/README.md
@@ -1,0 +1,74 @@
+# Treasury Logo Carousel Widget
+
+A clean, responsive logo carousel showcasing all 26 treasury technology vendors from the RealTreasury portal.
+
+## Features
+- Auto-scrolling at optimal speed (40s full cycle)
+- Drag/swipe functionality for manual control
+- Mobile-optimized with touch support
+- Clickable logos linking to vendor websites
+- Hover to pause auto-scroll
+- Seamless infinite loop
+
+## Usage
+Simply embed the `index.html` file into any webpage or use as an iframe:
+
+```html
+<iframe src="widgets/treasury-logo-carousel/index.html" width="100%" height="120" frameborder="0"></iframe>
+```
+
+### Customization
+- Adjust scroll speed by changing the animation duration in CSS (currently 40s)
+- Modify logo sizing in the responsive breakpoints
+- Update vendor data in the JavaScript array
+
+### Vendor Data
+Contains 26 treasury vendors with proper UTM tracking for analytics.
+
+## Integration Options
+The widget can be embedded in several ways:
+
+**Option A: Direct Embed**
+```html
+<div id="treasury-carousel-container"></div>
+<script>
+  fetch('/widgets/treasury-logo-carousel/index.html')
+    .then(response => response.text())
+    .then(html => {
+      document.getElementById('treasury-carousel-container').innerHTML = html;
+    });
+</script>
+```
+
+**Option B: iframe Embed**
+```html
+<iframe src="/widgets/treasury-logo-carousel/index.html" 
+        width="100%" 
+        height="120" 
+        frameborder="0"
+        style="border: none; display: block;">
+</iframe>
+```
+
+**Option C: Component Include (if using a framework)**
+```html
+<!-- For PHP includes -->
+<?php include 'widgets/treasury-logo-carousel/index.html'; ?>
+
+<!-- For Jekyll/static sites -->
+{% include widgets/treasury-logo-carousel/index.html %}
+```
+
+## Additional Notes
+- The widget is completely self-contained (no external dependencies)
+- All vendor logos are hosted on realtreasury.com CDN
+- UTM tracking parameters are included for analytics
+- Widget is responsive and works on all devices
+- File size is minimal (~15KB total)
+
+## Testing
+After adding the widget, test:
+- Auto-scroll functionality
+- Drag/swipe interactions on both desktop and mobile
+- Logo click-through to vendor websites
+- Responsive behavior on different screen sizes

--- a/widgets/treasury-logo-carousel/index.html
+++ b/widgets/treasury-logo-carousel/index.html
@@ -1,0 +1,410 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Treasury Vendors Carousel</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            background: #f8f9fa;
+        }
+
+        .carousel-container {
+            width: 100%;
+            overflow: hidden;
+            background: white;
+            border-top: 1px solid #e5e7eb;
+            border-bottom: 1px solid #e5e7eb;
+            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+            cursor: grab;
+        }
+
+        .carousel-container:active {
+            cursor: grabbing;
+        }
+
+        .carousel-track {
+            display: flex;
+            animation: scroll 40s linear infinite;
+            gap: 0;
+            user-select: none;
+        }
+
+        .carousel-track:hover {
+            animation-play-state: paused;
+        }
+
+        .carousel-track.dragging {
+            animation-play-state: paused;
+        }
+
+        .logo-slide {
+            min-width: 200px;
+            height: 100px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+            background: white;
+            border-right: 1px solid #f3f4f6;
+            flex-shrink: 0;
+            transition: background-color 0.3s ease;
+        }
+
+        .logo-slide:hover {
+            background-color: #f9fafb;
+        }
+
+        .logo-link {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+            text-decoration: none;
+            transition: opacity 0.3s ease;
+        }
+
+        .logo-link:hover {
+            opacity: 0.8;
+        }
+
+        .vendor-logo {
+            max-width: 140px;
+            max-height: 60px;
+            width: auto;
+            height: auto;
+            object-fit: contain;
+            filter: grayscale(30%);
+            transition: filter 0.3s ease;
+            user-select: none;
+            -webkit-user-drag: none;
+        }
+
+        .logo-slide:hover .vendor-logo {
+            filter: grayscale(0%);
+        }
+
+        @keyframes scroll {
+            0% {
+                transform: translateX(0);
+            }
+            100% {
+                transform: translateX(-50%);
+            }
+        }
+
+        /* Mobile optimizations */
+        @media (max-width: 768px) {
+            .logo-slide {
+                min-width: 150px;
+                height: 80px;
+                padding: 15px;
+            }
+            
+            .vendor-logo {
+                max-width: 100px;
+                max-height: 45px;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .logo-slide {
+                min-width: 120px;
+                height: 70px;
+                padding: 12px;
+            }
+            
+            .vendor-logo {
+                max-width: 80px;
+                max-height: 40px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="carousel-container">
+        <div class="carousel-track" id="carouselTrack">
+            <!-- Logos will be inserted here by JavaScript -->
+        </div>
+    </div>
+
+    <script>
+        const treasuryVendors = [
+            {
+                name: "Kyriba",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Kyriba.png",
+                websiteUrl: "https://www.kyriba.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "GTreasury",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/GTreasury.png",
+                websiteUrl: "https://gtreasury.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Reval",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png",
+                websiteUrl: "https://iongroup.com/products/treasury/reval/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Quantum",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/FIS.png",
+                websiteUrl: "#"
+            },
+            {
+                name: "WallStreet Suite",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png",
+                websiteUrl: "https://iongroup.com/products/treasury/wallstreet-suite/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "ATOM",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/ATOM-TM.png",
+                websiteUrl: "#"
+            },
+            {
+                name: "Integrity",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/FIS.png",
+                websiteUrl: "#"
+            },
+            {
+                name: "IT2",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png",
+                websiteUrl: "https://iongroup.com/products/treasury/it2/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Datalog",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Datalog-logo.png",
+                websiteUrl: "https://www.datalog-finance.com/en/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Coupa",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Coupa.png",
+                websiteUrl: "https://www.coupa.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Treasury Cube",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Treasury-Cube.png",
+                websiteUrl: "https://treasurycube.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Trovata",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Trovata.png",
+                websiteUrl: "https://trovata.io/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Tesorio",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Tesorio.jpg",
+                websiteUrl: "https://www.tesorio.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Autocash",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/AutoCash.png",
+                websiteUrl: "https://www.autocash.ai/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Balance",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Balance-Cash.jpg",
+                websiteUrl: "https://www.balancecash.io/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Nilus",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Nilus.png",
+                websiteUrl: "https://www.nilus.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Obol",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Obol.png",
+                websiteUrl: "https://www.obol.app/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Panax",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Panax.png",
+                websiteUrl: "https://www.thepanax.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Statement",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Statement.png",
+                websiteUrl: "https://www.statement.io/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Treasury Suite",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Treasury-Suite-Logo-PNG.png",
+                websiteUrl: "https://www.treasurysuite.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Vesto",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Vesto.png",
+                websiteUrl: "https://www.vesto.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Treasura",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png",
+                websiteUrl: "https://iongroup.com/products/treasury/treasura/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Treasury Curve",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Treasury-Curve.png",
+                websiteUrl: "https://www.treasurycurve.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Bottomline",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/bottomline-technologies-logo.png",
+                websiteUrl: "https://www.bottomline.com/us?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "City Financials",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/ION-Treasury.png",
+                websiteUrl: "https://iongroup.com/products/treasury/city-financials/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "HighRadius",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/High-Radius.png",
+                websiteUrl: "https://www.highradius.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            },
+            {
+                name: "Treasury4",
+                logoUrl: "https://realtreasury.com/wp-content/uploads/2025/06/Treasury4Logo-GraphiteGreen.png",
+                websiteUrl: "https://www.treasury4.com/?utm_source=realtreasury&utm_medium=website&utm_campaign=vendor_referral"
+            }
+        ];
+
+        function createLogoSlide(vendor) {
+            const slide = document.createElement('div');
+            slide.className = 'logo-slide';
+            
+            const link = document.createElement('a');
+            link.className = 'logo-link';
+            link.href = vendor.websiteUrl;
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+            
+            const img = document.createElement('img');
+            img.className = 'vendor-logo';
+            img.src = vendor.logoUrl;
+            img.alt = vendor.name + ' logo';
+            img.title = vendor.name;
+            img.draggable = false;
+            
+            link.appendChild(img);
+            slide.appendChild(link);
+            
+            return slide;
+        }
+
+        function initializeCarousel() {
+            const carouselTrack = document.getElementById('carouselTrack');
+            
+            // Create slides and duplicate for seamless loop
+            const slides = [];
+            treasuryVendors.forEach(vendor => {
+                slides.push(createLogoSlide(vendor));
+            });
+            
+            // Duplicate slides for seamless scrolling
+            const duplicatedSlides = [...slides, ...slides];
+            
+            duplicatedSlides.forEach(slide => {
+                carouselTrack.appendChild(slide);
+            });
+        }
+
+        // Initialize carousel when page loads
+        document.addEventListener('DOMContentLoaded', function() {
+            initializeCarousel();
+            setupDragScroll();
+        });
+
+        // Drag scroll functionality
+        function setupDragScroll() {
+            const container = document.querySelector('.carousel-container');
+            const track = document.getElementById('carouselTrack');
+            let isDown = false;
+            let startX;
+            let currentX = 0;
+            let hasMoved = false;
+
+            // Mouse events
+            container.addEventListener('mousedown', (e) => {
+                isDown = true;
+                hasMoved = false;
+                track.classList.add('dragging');
+                startX = e.pageX;
+                container.style.cursor = 'grabbing';
+                e.preventDefault();
+            });
+
+            container.addEventListener('mouseleave', () => {
+                isDown = false;
+                track.classList.remove('dragging');
+                container.style.cursor = 'grab';
+                resumeAnimation();
+            });
+
+            container.addEventListener('mouseup', () => {
+                isDown = false;
+                track.classList.remove('dragging');
+                container.style.cursor = 'grab';
+                setTimeout(resumeAnimation, 1000);
+            });
+
+            container.addEventListener('mousemove', (e) => {
+                if (!isDown) return;
+                e.preventDefault();
+                const x = e.pageX;
+                const walk = (x - startX) * 1.5;
+                if (Math.abs(walk) > 5) hasMoved = true;
+                currentX += walk;
+                track.style.transform = `translateX(${currentX}px)`;
+                startX = x;
+            });
+
+            // Touch events for mobile
+            container.addEventListener('touchstart', (e) => {
+                isDown = true;
+                hasMoved = false;
+                track.classList.add('dragging');
+                startX = e.touches[0].pageX;
+            }, { passive: true });
+
+            container.addEventListener('touchend', () => {
+                isDown = false;
+                track.classList.remove('dragging');
+                setTimeout(resumeAnimation, 1000);
+            });
+
+            container.addEventListener('touchmove', (e) => {
+                if (!isDown) return;
+                const x = e.touches[0].pageX;
+                const walk = (x - startX) * 1.5;
+                if (Math.abs(walk) > 5) hasMoved = true;
+                currentX += walk;
+                track.style.transform = `translateX(${currentX}px)`;
+                startX = x;
+            }, { passive: true });
+
+            // Prevent link clicks when dragging
+            container.addEventListener('click', (e) => {
+                if (hasMoved) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }, true);
+
+            // Resume animation
+            function resumeAnimation() {
+                if (!track.classList.contains('dragging')) {
+                    track.style.transform = '';
+                    currentX = 0;
+                }
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new Treasury Logo Carousel widget with vendor data
- include usage instructions in README

## Testing
- `npm install`
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686c343a4ed88331b98aa5974abf4f19