### PR TITLE
Update treasury logo widget heading

### DIFF
--- a/widgets/treasury-logo-carousel/README.md
+++ b/widgets/treasury-logo-carousel/README.md
@@ -2,7 +2,7 @@
 
 A clean, responsive logo carousel showcasing all 27 treasury technology vendors from the RealTreasury portal with a professional header.
 
-- **Professional Header**: Displays "Treasury Technology Vendors" title with vendor count
+- **Professional Header**: Displays "North American Treasury Tech Vendors" heading with vendor count
 - **True Infinite Scroll**: Seamless continuous loop with no visible jumps or resets
 - **Optimized Performance**: Smooth 40-second full cycle with hardware acceleration
 - **Interactive Controls**: Drag/swipe functionality for manual control

--- a/widgets/treasury-logo-carousel/index.html
+++ b/widgets/treasury-logo-carousel/index.html
@@ -26,22 +26,10 @@
         }
 
         .widget-header {
-            background: linear-gradient(135deg, #7216f4, #8f47f6);
+            background: #7216f4;
             color: #fff;
             padding: 16px 24px;
             text-align: center;
-            position: relative;
-        }
-
-        .widget-header::before {
-            content: "";
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 100%;
-            background: linear-gradient(135deg, rgba(255,255,255,0.1), transparent);
-            pointer-events: none;
         }
 
         .widget-title {
@@ -180,8 +168,8 @@
 <body>
     <div class="widget-container">
         <div class="widget-header">
-            <div class="widget-title">Treasury Technology Vendors</div>
-            <div class="widget-subtitle">27 vendors</div>
+            <div class="widget-title">North American Treasury Tech Vendors</div>
+            <div class="widget-subtitle">27 vendors featured in our market chart</div>
         </div>
         <div class="carousel-container">
             <div class="carousel-track auto-scroll" id="carouselTrack"></div>


### PR DESCRIPTION
## Summary
- use solid purple background for widget-header
- change heading to **North American Treasury Tech Vendors**
- note the new heading in README
- mention vendor chart in subtitle

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686c4672313c8331a0ce8855a0c76a2c