### PR TITLE
Fix nav dropdown gap on banner transition

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1297,13 +1297,13 @@ body.modal-open {
     /* Remove any border-bottom that might create spacing */
 }
 
-body.banner-present .rt-nav-container {
-    top: 80px;
+/* Override any banner-specific nav positioning that might interfere */
+body.banner-present .rt-nav-container,
+body.banner-minimized .rt-nav-container,
+body.banner-closed .rt-nav-container {
+    /* Let the banner JavaScript handle positioning, don't override here */
 }
-body.banner-closed .rt-nav-container,
-body:not(.banner-present) .rt-nav-container {
-    top: 0;
-}
+
 
 body.banner-closed {
     padding-top: 80px !important;

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -501,6 +501,21 @@ function closeBanner(event) {
     banner.classList.add('minimized');
     document.body.classList.add('banner-minimized');
     updateBannerState(); // Add this line
+
+    // Force dropdown recalculation after banner transition
+    setTimeout(() => {
+        const dropdowns = document.querySelectorAll('.rt-dropdown');
+        dropdowns.forEach(dropdown => {
+            // Force browser to recalculate positioning
+            dropdown.style.transform = 'translateY(-10px)';
+            setTimeout(() => {
+                if (dropdown.closest('.rt-nav-item.active')) {
+                    dropdown.style.transform = 'translateY(0)';
+                }
+            }, 10);
+        });
+    }, 300); // After banner transition completes
+
     const closeBtn = banner.querySelector('.close-btn');
     if (closeBtn) closeBtn.style.display = 'none';
 


### PR DESCRIPTION
## Summary
- remove banner-specific positioning on `.rt-nav-container`
- allow JS to recalc dropdown positions when banner minimizes

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686c469d621c833189784ccd8f223a18