### PR TITLE
Adjust insights menu heading overlay

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1618,6 +1618,12 @@ body.banner-closed {
     border: 1px solid rgba(114, 22, 244, 0.2);
 }
 
+/* Ensure overlay positions relative to the explore image link */
+.rt-explore-link {
+    position: relative;
+    display: block;
+}
+
 /* Overlay title used in the Insights dropdown image */
 .chart-title-overlay {
     position: absolute;

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -31,8 +31,7 @@ function add_my_custom_header_html() {
                         <div class="rt-dropdown-inner">
                             <div class="rt-main-menu">
                                 <div class="rt-main-menu-column">
-                                    <h3>Explore</h3>
-                                    <a href="https://realtreasury.com/treasury-tech-market/">
+                                    <a href="https://realtreasury.com/treasury-tech-market/" class="rt-explore-link">
                                         <div class="chart-title-overlay">
                                             <h3>Treasury &amp; Risk Management Systems</h3>
                                             <p>North America</p>


### PR DESCRIPTION
## Summary
- replace the "Explore" heading in the Insights dropdown with a link that positions the overlay correctly
- ensure overlay text is positioned relative to the explore image link

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686c767332d88331a2e0f523f8ffa90c