### PR TITLE
Remove mobile dropdown overrides

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1427,21 +1427,6 @@ body.banner-closed {
     padding: 2.5rem 2rem;
 }
 
-@media (max-width: 992px) {
-    .rt-dropdown {
-        position: static !important;
-        width: 100% !important;
-        margin-left: 0 !important;
-        border-radius: 12px !important;
-        margin-top: 0.5rem !important;
-        border-top: 1px solid rgba(199, 125, 255, 0.3) !important;
-        transform: none !important;
-    }
-
-    .rt-nav-item.active .rt-dropdown {
-        display: block !important;
-    }
-}
 
 /* Hide dropdowns when mobile menu is open */
 @media (max-width: 992px) {
@@ -1918,31 +1903,6 @@ body.banner-closed {
     
     .rt-nav-link.has-dropdown::after {
         border-top-color: var(--dark-text) !important;
-    }
-    
-    .rt-dropdown {
-        position: static !important;
-        top: auto !important;
-        width: 100% !important;
-        box-shadow: none !important;
-        border-radius: 12px !important;
-        background: rgba(255, 255, 255, 0.8) !important;
-        backdrop-filter: blur(10px) !important;
-        -webkit-backdrop-filter: blur(10px) !important;
-        border: 1px solid rgba(199, 125, 255, 0.3) !important;
-        border-top: 1px solid rgba(199, 125, 255, 0.3) !important;
-        opacity: 1 !important;
-        visibility: visible !important;
-        transform: none !important;
-        display: none !important;
-        margin-top: 0 !important; /* Remove margin that could create gaps */
-        padding: 0 !important;
-        pointer-events: auto !important;
-    }
-
-    .rt-nav-item.active .rt-dropdown {
-        display: block !important;
-        border-top: 1px solid rgba(199, 125, 255, 0.3) !important;
     }
     
     .rt-dropdown-inner {


### PR DESCRIPTION
## Summary
- remove mobile dropdown overrides so banner JS can control position

## Testing
- `npm run test:ejs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c7cdb75048331877954fbe70b1ba3