### PR TITLE
Fix navigation dropdown menu

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1397,39 +1397,48 @@ body.banner-closed {
     z-index: 1000001;
 }
 
-.rt-nav-item.active .rt-nav-link.has-dropdown::after {
-    content: "";
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: linear-gradient(135deg, hsla(0, 0%, 100%, .85), hsla(0, 0%, 97%, .9));
-    z-index: 1000002;
-}
+/*
+ * Removed pseudo-element that attempted to visually bridge the
+ * navigation item and its dropdown. This element caused an unwanted
+ * gap when the dropdown was positioned absolutely.
+ */
 
 /* Dropdown Menu - FIXED VERSION */
 .rt-dropdown {
-    position: absolute !important;
-    top: calc(100% - 1px) !important;
+    position: fixed !important;
+    top: 80px !important;
     left: 0 !important;
     right: 0 !important;
     width: 100vw !important;
-    margin-left: calc(-50vw + 50%) !important;
+    /* Fixed positioning approach - no complex calc() needed */
+    margin-left: 0 !important;
     background: linear-gradient(135deg, hsla(0, 0%, 100%, .85), hsla(0, 0%, 97%, .9)) !important;
     backdrop-filter: blur(20px) saturate(130%) !important;
     -webkit-backdrop-filter: blur(20px) saturate(130%) !important;
     border: 1px solid rgba(199, 125, 255, .2) !important;
-    border-top: 1px solid rgba(199, 125, 255, .1) !important; /* Add subtle top border */
+    border-top: none !important;
     box-shadow: 0 8px 32px rgba(114, 22, 244, .12), inset 0 1px 0 hsla(0, 0%, 100%, .8), inset 0 -1px 0 rgba(0, 0, 0, .03) !important;
     border-radius: 0 0 16px 16px !important;
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-5px); /* Reduce initial offset */
+    transform: translateY(-10px);
     transition: all 0.3s ease;
     z-index: 1000000;
     overflow: hidden;
     pointer-events: none;
+}
+
+/* Adjust dropdown positioning based on banner state */
+body.banner-present .rt-dropdown {
+    top: 160px !important;
+}
+
+body.banner-minimized .rt-dropdown {
+    top: 140px !important;
+}
+
+body.banner-closed .rt-dropdown {
+    top: 80px !important;
 }
 
 /* Remove any bottom spacing from navigation wrapper */
@@ -1469,8 +1478,13 @@ body.banner-closed {
 
 @media (max-width: 992px) {
     .rt-dropdown {
-        top: calc(100% - 2px) !important; /* Slightly more overlap on mobile */
-        border-radius: 0 0 12px 12px !important;
+        top: 70px !important;
+    }
+    
+    body.banner-present .rt-dropdown,
+    body.banner-minimized .rt-dropdown,
+    body.banner-closed .rt-dropdown {
+        top: 70px !important;
     }
 }
 


### PR DESCRIPTION
## Fix Navigation Dropdown Menu Issues

### Problem
- Gap between navigation bar and dropdown menu
- Dropdown did not span the full viewport width
- Complex positioning calculations caused layout problems

### Solution
- Replaced absolute positioning with fixed layout
- Removed pseudo-element bridging gap
- Added banner-aware positioning and simplified mobile behavior

### Changes
- Modified `.rt-dropdown` styles in `assets/css/shared.css`
- Removed complex gap pseudo-element
- Updated mobile positioning rules

### Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686c83ed120c8331bb5394490ff4026c