### PR TITLE
Fix chart title overlay in dropdown

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1703,6 +1703,18 @@ body.banner-closed {
     }
 }
 
+/* Smaller overlay text inside the main menu dropdown */
+.rt-main-menu .chart-title-overlay {
+    min-width: 260px;
+    padding: 8px 14px;
+}
+.rt-main-menu .chart-title-overlay h3 {
+    font-size: 1.1rem;
+}
+.rt-main-menu .chart-title-overlay p {
+    font-size: 0.85rem;
+}
+
 /* Insights Widget */
 .rt-insights-widget {
     width: 100%;


### PR DESCRIPTION
## Summary
- refine CSS for chart title overlay inside the main menu dropdown

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c84e7f2088331870f4465d7645a05