### PR TITLE
Fix menu heading size

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1723,7 +1723,7 @@ body.banner-closed .rt-dropdown {
     padding: 8px 14px;
 }
 .rt-main-menu .chart-title-overlay h3 {
-    font-size: 1.1rem;
+    font-size: 0.85rem;
 }
 .rt-main-menu .chart-title-overlay p {
     font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- adjust heading size in the main menu overlay

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686c86dc48cc8331926a8e31250f0f89