### PR TITLE
Style update for insights dropdown title

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1719,14 +1719,16 @@ body.banner-closed .rt-dropdown {
 
 /* Smaller overlay text inside the main menu dropdown */
 .rt-main-menu .chart-title-overlay {
-    min-width: 260px;
+    min-width: 0;
+    max-width: 100%;
     padding: 8px 14px;
 }
 .rt-main-menu .chart-title-overlay h3 {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
+    white-space: normal;
 }
 .rt-main-menu .chart-title-overlay p {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
 }
 
 /* Insights Widget */


### PR DESCRIPTION
## Summary
- tweak `.chart-title-overlay` styles in the main menu dropdown so long titles fit better

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c87f5486c8331a091930dd8248f7f