### PR TITLE
Fix navigation dropdown gap

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1403,43 +1403,30 @@ body.banner-closed {
  * gap when the dropdown was positioned absolutely.
  */
 
-/* Dropdown Menu - FIXED VERSION */
+/* Dropdown Menu */
 .rt-dropdown {
-    position: fixed !important;
-    top: 80px !important;
+    position: absolute !important;
+    top: calc(100% - 1px) !important;
     left: 0 !important;
     right: 0 !important;
     width: 100vw !important;
-    /* Fixed positioning approach - no complex calc() needed */
-    margin-left: 0 !important;
+    margin-left: calc(-50vw + 50%) !important;
     background: linear-gradient(135deg, hsla(0, 0%, 100%, .85), hsla(0, 0%, 97%, .9)) !important;
     backdrop-filter: blur(20px) saturate(130%) !important;
     -webkit-backdrop-filter: blur(20px) saturate(130%) !important;
     border: 1px solid rgba(199, 125, 255, .2) !important;
-    border-top: none !important;
+    border-top: 1px solid rgba(199, 125, 255, .1) !important;
     box-shadow: 0 8px 32px rgba(114, 22, 244, .12), inset 0 1px 0 hsla(0, 0%, 100%, .8), inset 0 -1px 0 rgba(0, 0, 0, .03) !important;
     border-radius: 0 0 16px 16px !important;
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-10px);
+    transform: translateY(-5px);
     transition: all 0.3s ease;
     z-index: 1000000;
     overflow: hidden;
     pointer-events: none;
 }
 
-/* Adjust dropdown positioning based on banner state */
-body.banner-present .rt-dropdown {
-    top: 160px !important;
-}
-
-body.banner-minimized .rt-dropdown {
-    top: 140px !important;
-}
-
-body.banner-closed .rt-dropdown {
-    top: 80px !important;
-}
 
 /* Remove any bottom spacing from navigation wrapper */
 .rt-nav-wrapper {
@@ -1476,17 +1463,6 @@ body.banner-closed .rt-dropdown {
     }
 }
 
-@media (max-width: 992px) {
-    .rt-dropdown {
-        top: 70px !important;
-    }
-    
-    body.banner-present .rt-dropdown,
-    body.banner-minimized .rt-dropdown,
-    body.banner-closed .rt-dropdown {
-        top: 70px !important;
-    }
-}
 
 /* Main Menu Layout */
 .rt-main-menu {


### PR DESCRIPTION
## Summary
- restore `position: absolute` dropdown strategy
- remove banner-specific overrides
- remove mobile dropdown override

## Testing
- `npm run test:ejs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c882c3a4883319111bdcfd6950b14