### PR TITLE
Fix chart title overlay text

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1700,8 +1700,8 @@ body.banner-closed {
     padding: 8px 14px;
 }
 .rt-main-menu .chart-title-overlay h3 {
-    font-size: 0.75rem;
-    white-space: normal;
+    font-size: 0.6rem;
+    white-space: nowrap;
 }
 .rt-main-menu .chart-title-overlay p {
     font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- keep chart overlay title to a single line within Insights dropdown

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686c8b36a5548331ba5c86f06e74b9c8