### PR TITLE
Fix: Make navigation dropdown menus full viewport width

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1411,11 +1411,11 @@ body.banner-closed {
 
 /* Dropdown Menu - FIXED VERSION */
 .rt-dropdown {
-    /* Use absolute positioning attached directly to nav item */
-    position: absolute !important;
-    top: 100% !important;
-    left: 50% !important;
-    transform: translateX(-50%) !important;
+    /* Use fixed positioning for true full-width */
+    position: fixed !important;
+    top: 80px !important; /* Height of nav bar */
+    left: 0 !important;
+    right: 0 !important;
     width: 100vw !important;
     max-width: 100vw !important;
 
@@ -1428,7 +1428,7 @@ body.banner-closed {
     box-shadow: 0 8px 32px rgba(114, 22, 244, .12) !important;
     border-radius: 0 0 16px 16px !important;
 
-    /* Visibility controls - NO TRANSFORMS that could create gaps */
+    /* Visibility controls */
     opacity: 0;
     visibility: hidden;
     pointer-events: none;
@@ -1439,10 +1439,37 @@ body.banner-closed {
     z-index: 1000000;
     overflow: hidden;
 
-    /* CRITICAL: Remove all margins, padding that could create space */
+    /* Remove all margins, padding that could create space */
     margin: 0 !important;
     padding: 0 !important;
 }
+
+
+/* Adjust dropdown position based on banner state */
+body.banner-present .rt-dropdown {
+    top: 160px !important; /* 80px banner + 80px nav */
+}
+
+body.banner-minimized .rt-dropdown {
+    top: 140px !important; /* 60px minimized banner + 80px nav */
+}
+
+body.banner-closed .rt-dropdown {
+    top: 80px !important; /* Just nav height */
+}
+
+@media (max-width: 992px) {
+    .rt-dropdown {
+        top: 70px !important; /* Mobile nav height */
+    }
+    body.banner-present .rt-dropdown {
+        top: 150px !important;
+    }
+    body.banner-minimized .rt-dropdown {
+        top: 130px !important;
+    }
+}
+
 
 .rt-nav-item.active .rt-dropdown {
     opacity: 1 !important;
@@ -1478,7 +1505,6 @@ body.banner-closed {
 .rt-nav-item.active .rt-dropdown {
     margin-top: 0 !important;
     padding-top: 0 !important;
-    top: calc(100% + 0px) !important; /* Absolutely flush */
 }
 
 /* Remove any potential spacing from dropdown container */


### PR DESCRIPTION
## Summary
- update `.rt-dropdown` positioning so dropdown spans the viewport
- add banner-state positioning rules for dropdown
- remove old calc-based adjustment

## Testing
- `npm run test:ejs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c9a9e61a88331bbe13c975c40c705