### PR TITLE
Fix vendor label alignment in logo carousel

### DIFF
--- a/widgets/treasury-logo-carousel/index.html
+++ b/widgets/treasury-logo-carousel/index.html
@@ -76,7 +76,7 @@
 
         .logo-slide {
             min-width: 200px;
-            height: 120px;
+            min-height: 120px;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -97,7 +97,6 @@
             align-items: center;
             justify-content: center;
             width: 100%;
-            height: 100%;
             text-decoration: none;
             transition: opacity 0.3s ease;
         }
@@ -122,6 +121,7 @@
             margin-top: 6px;
             font-size: 0.85rem;
             color: #111827;
+            width: 100%;
             text-align: center;
         }
 
@@ -141,7 +141,7 @@
         @media (max-width: 768px) {
             .logo-slide {
                 min-width: 150px;
-                height: 100px;
+                min-height: 100px;
                 padding: 15px;
             }
 
@@ -154,7 +154,7 @@
         @media (max-width: 480px) {
             .logo-slide {
                 min-width: 120px;
-                height: 90px;
+                min-height: 90px;
                 padding: 12px;
             }
 


### PR DESCRIPTION
## Summary
- let logo slides expand to fit vendor names
- remove fixed link height so names can sit below logos
- make vendor name element full width

## Testing
- `npm run test:ejs --silent`


------
https://chatgpt.com/codex/tasks/task_e_686c9b71c2448331ae12421bb659109e