### PR TITLE
Fix TPA cookie handler form ID

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1257,7 +1257,8 @@ function tpa_basic_fallback_gate() {
 
 add_action('wpcf7_mail_sent', 'tpa_enhanced_cookie_handler', 10, 1);
 function tpa_enhanced_cookie_handler($contact_form) {
-    if ($contact_form->id() != 'YOUR_FORM_ID_HERE') {
+    $selected_id = get_option('tpa_form_id');
+    if (!$selected_id || $contact_form->id() != $selected_id) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- use the configured Contact Form 7 form ID when setting gate cookies

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686d5167e160833194ad743e0b57c91d