### PR TITLE
Add portal gate setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,20 @@ manually copy the file contents into WordPress:
 3. Paste the CSS into the editor and click **Publish**.
 
 Repeat these steps whenever `shared.css` changes in Git.
+
+## Portal Access Gate
+
+The repository includes the **Treasury Portal Access** plugin (`plugins/treasury-portal-access`) used to protect the Treasury Tech Portal page.
+
+### Setup
+
+1. Install and activate **Contact Form 7** and **Treasury Portal Access** in WordPress.
+2. Go to **Portal Access → Settings** and choose the Contact Form 7 form that will grant portal access (this stores the form ID used by the plugin).
+3. Place the `[portal_button]` shortcode on the portal page (and wrap protected sections in `[protected_content]...[/protected_content]`).
+4. If you rely on the fallback gate instead of the plugin, edit `assets/php/functions.php` and replace `YOUR_FORM_ID_HERE` with your form ID.
+
+### Testing
+
+1. Visit the portal page in a private or incognito window.
+2. Submit the access form and verify you are redirected to your portal page.
+3. Refresh the page to confirm protected content remains visible while the cookie is active.


### PR DESCRIPTION
## Summary
- document portal access gate installation
- explain how to configure the Contact Form 7 form ID using plugin settings or the fallback gate

## Testing
- `npm install`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686d516988788331aae0f2c6436afa0b