### PR TITLE
Fix cookie access and link behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,4 @@ The repository includes the **Treasury Portal Access** plugin (`plugins/treasury
 1. Visit the portal page in a private or incognito window.
 2. Submit the access form and verify you are redirected to your portal page.
 3. Refresh the page to confirm protected content remains visible while the cookie is active.
+4. Click the original portal button again and ensure it now navigates directly to the portal instead of reopening the form.

--- a/plugins/treasury-portal-access/includes/frontend-scripts.php
+++ b/plugins/treasury-portal-access/includes/frontend-scripts.php
@@ -355,6 +355,12 @@ if (empty($form_id)) {
                     e.preventDefault();
                     this.closeModal();
                 }
+
+                const btn = e.target.closest('[data-href]');
+                if (btn && !btn.classList.contains('open-portal-modal')) {
+                    e.preventDefault();
+                    window.location.href = btn.getAttribute('data-href');
+                }
             });
 
             document.addEventListener('keydown', e => {

--- a/plugins/treasury-portal-access/treasury-portal-access.php
+++ b/plugins/treasury-portal-access/treasury-portal-access.php
@@ -233,7 +233,8 @@ final class Treasury_Portal_Access {
             'path'     => COOKIEPATH,
             'domain'   => COOKIE_DOMAIN,
             'secure'   => is_ssl(),
-            'httponly' => true,
+            // Frontend scripts need to read this cookie to update buttons
+            'httponly' => false,
             'samesite' => 'Lax'
         ];
         setcookie('portal_access_token', $access_token, $options);


### PR DESCRIPTION
## Summary
- allow JS to read `portal_access_token` cookie
- trigger navigation for buttons after access is granted
- document redirect test

## Testing
- `npm run test:ejs`
- `node test/ejs-test.js`


------
https://chatgpt.com/codex/tasks/task_e_686d67505c888331a3364a46669e148e