### PR TITLE
Fix cookie fallback when plugin active

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1256,8 +1256,16 @@ function tpa_basic_fallback_gate() {
     }
 }
 
-add_action('wpcf7_mail_sent', 'tpa_enhanced_cookie_handler', 10, 1);
+// Skip fallback handler when official plugin is active
+if ( ! class_exists( 'Treasury_Portal_Access' ) ) {
+    add_action( 'wpcf7_mail_sent', 'tpa_enhanced_cookie_handler', 10, 1 );
+}
 function tpa_enhanced_cookie_handler($contact_form) {
+    // Skip fallback cookie when official plugin handles access
+    if ( class_exists( 'Treasury_Portal_Access' ) ) {
+        return;
+    }
+
     $portal_form_id = get_option('tpa_form_id');
 
     // Auto-detect the form if no ID configured


### PR DESCRIPTION
## Summary
- disable fallback cookie handler when `Treasury_Portal_Access` plugin is active
- short-circuit inside `tpa_enhanced_cookie_handler`

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686d696435c483319914a789f8aff7e1