### PR TITLE
Fix tagline copy on ERR NOT page

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -212,7 +212,7 @@
                 The <span class="gradient-text">ERR NOT™</span> Method
             </h1>
             <p class="text-xl md:text-2xl text-gray-600 mb-8 max-w-4xl mx-auto">
-                Treasury's smarter, faster way to select technology—independent and repeatable.
+                Real Treasury's smarter, faster way to select technology—independent and repeatable.
             </p>
             
             <!-- Simplified Hero CTAs - Just 2 clear options -->


### PR DESCRIPTION
## Summary
- update hero copy on the ERR NOT page

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d7b4734888331a43b1813ea6b7679