### PR TITLE
Enhance dropdown transparency with stronger blur effects

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1495,6 +1495,7 @@ body.banner-closed {
  */
 
 /* Dropdown Menu - SIMPLIFIED SEAMLESS VERSION */
+
 .rt-dropdown {
     position: absolute !important;
     top: 100% !important;
@@ -1504,14 +1505,17 @@ body.banner-closed {
     display: flex;
     justify-content: center;
 
-    /* Style properties */
-    background: linear-gradient(135deg, hsla(0, 0%, 100%, .85), hsla(0, 0%, 97%, .9)) !important;
-    backdrop-filter: blur(20px) saturate(130%) !important;
-    -webkit-backdrop-filter: blur(20px) saturate(130%) !important;
-    border: 1px solid rgba(199, 125, 255, .2) !important;
+    /* Updated style properties for near transparency with strong blur */
+    background: linear-gradient(135deg,
+        hsla(0, 0%, 100%, .12),
+        hsla(0, 0%, 97%, .18) 50%,
+        hsla(0, 0%, 100%, .12)) !important;
+    backdrop-filter: blur(35px) saturate(160%) brightness(1.1) !important;
+    -webkit-backdrop-filter: blur(35px) saturate(160%) brightness(1.1) !important;
+    border: 1px solid rgba(199, 125, 255, .15) !important;
     border-top: none !important;
-    box-shadow: 0 8px 32px rgba(114, 22, 244, .12) !important;
-    border-radius: 0 !important; /* Remove border radius to prevent gaps */
+    box-shadow: 0 8px 32px rgba(114, 22, 244, .08), 0 0 0 1px rgba(255, 255, 255, .3) inset !important;
+    border-radius: 0 !important;
 
     /* Visibility controls */
     opacity: 0;
@@ -1525,7 +1529,7 @@ body.banner-closed {
     /* CRITICAL: Allow JavaScript to set positioning */
     margin: 0 !important;
     padding: 0 !important;
-    transform: none !important; /* Remove conflicting transforms */
+    transform: none !important;
 }
 
 .rt-nav-item.active .rt-dropdown {
@@ -1545,6 +1549,22 @@ body.banner-closed {
     left: auto !important;
     right: auto !important;
     transform: none !important;
+    /* Add subtle inner background for better text contrast */
+    background: linear-gradient(135deg,
+        rgba(255, 255, 255, 0.08),
+        rgba(255, 255, 255, 0.04) 50%,
+        rgba(255, 255, 255, 0.08)) !important;
+    border-radius: 8px !important;
+}
+
+/* Enhance text contrast for better readability on transparent background */
+.rt-main-menu-link,
+.rt-about-link,
+.rt-service-title,
+.rt-about-story h3,
+.rt-about-story p,
+.rt-about-description p {
+    text-shadow: 0 1px 3px rgba(255, 255, 255, 0.8) !important;
 }
 
 /* =================================================================== */
@@ -1635,21 +1655,26 @@ body.banner-closed {
 
 .rt-service-item {
     padding: 1.5rem;
-    background: rgba(255, 255, 255, 0.4);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
+    background: rgba(255, 255, 255, 0.25) !important;
+    backdrop-filter: blur(15px) saturate(120%) !important;
+    -webkit-backdrop-filter: blur(15px) saturate(120%) !important;
     border-radius: 12px;
-    border: 1px solid rgba(114, 22, 244, 0.1);
+    border: 1px solid rgba(114, 22, 244, 0.15) !important;
     transition: all 0.3s ease;
     cursor: pointer;
     text-align: center;
+    box-shadow: 
+        0 4px 16px rgba(114, 22, 244, 0.08),
+        0 0 0 1px rgba(255, 255, 255, 0.4) inset !important;
 }
 
 .rt-service-item:hover {
-    background: rgba(255, 255, 255, 0.6);
+    background: rgba(255, 255, 255, 0.35) !important;
     transform: translateY(-4px);
-    box-shadow: 0 8px 24px rgba(114, 22, 244, 0.15);
-    border-color: rgba(114, 22, 244, 0.3);
+    box-shadow: 
+        0 8px 24px rgba(114, 22, 244, 0.12),
+        0 0 0 1px rgba(255, 255, 255, 0.5) inset !important;
+    border-color: rgba(114, 22, 244, 0.25) !important;
 }
 
 .rt-service-title {
@@ -2347,6 +2372,11 @@ body.banner-closed {
         left: auto !important;
         right: auto !important;
         transform: none !important;
+        background: linear-gradient(135deg,
+            rgba(255, 255, 255, 0.08),
+            rgba(255, 255, 255, 0.04) 50%,
+            rgba(255, 255, 255, 0.08)) !important;
+        border-radius: 8px !important;
     }
     
     .rt-main-menu {


### PR DESCRIPTION
## Summary
- reduce dropdown background opacity and increase blur
- improve dropdown inner contrast and add text shadows
- update service item backgrounds with glass styling

## Testing
- `npm install`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686d9019d17c8331b8d81b36aa5c6060