### PR TITLE
Update vendor counts to 28

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -565,7 +565,7 @@
                 <div class="bg-white rounded-2xl p-8 border border-purple-200 shadow-md">
                     <div class="text-4xl mb-4">🎥</div>
                     <h3 class="text-xl font-bold mb-4">Explore the Portal</h3>
-                    <p class="text-gray-600 mb-6 text-sm">Access and compare 27+ vendors and videos</p>
+                    <p class="text-gray-600 mb-6 text-sm">Access and compare 28+ vendors and videos</p>
                     <a href="https://realtreasury.com/treasury-tech-portal/" class="w-full text-center block cta-secondary tpa-btn-ready">
                         Access Tech Portal
                     </a>

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -31,7 +31,7 @@ if (!defined("ABSPATH")) exit;
 
                     <div class="stats-bar">
                         <div class="stat-card">
-                            <div class="stat-number" id="totalTools">27</div>
+                            <div class="stat-number" id="totalTools">28</div>
                             <div class="stat-label">Tools</div>
                         </div>
                         <div class="stat-card">

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -425,7 +425,7 @@
         <div class="container">
             <div class="hero-content">
                 <h1>Treasury Tech<br>Made Simple</h1>
-                <p class="hero-subtitle">Three clear categories to help you navigate 27+ treasury technology solutions and find the perfect fit for your organization.</p>
+                <p class="hero-subtitle">Three clear categories to help you navigate 28+ treasury technology solutions and find the perfect fit for your organization.</p>
                 
                 <div class="hero-image">
                     <img src="https://realtreasury.com/wp-content/uploads/2025/07/Portal-Landing.png" alt="Treasury Tech Portal" loading="lazy">

--- a/widgets/treasury-logo-carousel/README.md
+++ b/widgets/treasury-logo-carousel/README.md
@@ -1,6 +1,6 @@
 # Treasury Logo Carousel Widget
 
-A clean, responsive logo carousel showcasing all 27 treasury technology vendors from the RealTreasury portal with a professional header.
+A clean, responsive logo carousel showcasing all 28 treasury technology vendors from the RealTreasury portal with a professional header.
 
 - **Professional Header**: Displays "North American Treasury Tech Vendors" heading with vendor count
 - **True Infinite Scroll**: Seamless continuous loop with no visible jumps or resets
@@ -24,7 +24,7 @@ Simply embed the `index.html` file into any webpage or use as an iframe:
 - Customize header text and styling in the widget-header section
 
 ### Vendor Data
-Contains 27 treasury vendors with proper UTM tracking for analytics.
+Contains data for 28 treasury technology vendors with proper UTM tracking for analytics.
 
 ## Integration Options
 The widget can be embedded in several ways:

--- a/widgets/treasury-logo-carousel/index.html
+++ b/widgets/treasury-logo-carousel/index.html
@@ -169,7 +169,7 @@
     <div class="widget-container">
         <div class="widget-header">
             <div class="widget-title">North American Treasury Tech Vendors</div>
-            <div class="widget-subtitle">27 vendors featured in our market chart</div>
+            <div class="widget-subtitle">28 vendors featured in our market chart</div>
         </div>
         <div class="carousel-container">
             <div class="carousel-track auto-scroll" id="carouselTrack"></div>


### PR DESCRIPTION
## Summary
- update carousel subtitle to show 28 vendors
- mention 28 treasury technology vendors in carousel README
- adjust CTA copy in errnot page
- tweak hero subtitle of tech market page
- increase totalTools value in portal shortcode

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686d97532d408331849c389529c43947