### PR TITLE
Adjust services dropdown copy and compact styling

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -3961,14 +3961,15 @@ a[href="#openportalmodal"] {
 .rt-services-enhanced .rt-services-grid {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem; /* Reduced from 1rem */
+    gap: 0.5rem; /* Reduce from 0.75rem */
 }
 
 .rt-services-enhanced .rt-service-item {
     background: rgba(255, 255, 255, 0.9);
     backdrop-filter: blur(8px);
     border-radius: 10px;
-    padding: 1rem; /* Reduced from 1.25rem */
+    padding: 0.75rem; /* Reduce from 1rem */
+    margin-bottom: 0.5rem; /* Reduce spacing between cards */
     border: 1px solid rgba(114, 22, 244, 0.1);
     transition: all 0.25s ease;
     position: relative;
@@ -4019,23 +4020,24 @@ a[href="#openportalmodal"] {
 }
 
 .rt-services-enhanced .rt-service-title {
-    font-size: 0.95rem; /* Reduced from 1rem */
+    font-size: 0.9rem; /* Reduce from 0.95rem */
     font-weight: 600;
     color: var(--dark-text);
     line-height: 1.2;
+    margin-bottom: 0.4rem; /* Add tighter spacing */
 }
 
 .rt-services-enhanced .rt-service-desc {
     color: var(--gray-text);
-    font-size: 0.8rem; /* Reduced from 0.85rem */
-    line-height: 1.4;
-    margin-bottom: 0.6rem; /* Reduced from 0.875rem */
+    font-size: 0.75rem; /* Reduce from 0.8rem */
+    line-height: 1.3; /* Tighten from 1.4 */
+    margin-bottom: 0.5rem; /* Reduce from 0.6rem */
 }
 
 .rt-service-features {
     display: flex;
-    gap: 0.375rem;
-    margin-bottom: 0.75rem; /* Reduced from 1rem */
+    gap: 0.25rem; /* Reduce from 0.375rem */
+    margin-bottom: 0.5rem; /* Reduce from 0.75rem */
     flex-wrap: wrap;
 }
 
@@ -4056,13 +4058,13 @@ a[href="#openportalmodal"] {
     background: linear-gradient(135deg, var(--primary-purple), var(--secondary-purple));
     color: white;
     text-decoration: none;
-    padding: 0.5rem 0.875rem; /* Reduced from 0.625rem 1rem */
-    border-radius: 6px;
-    font-size: 0.75rem; /* Reduced from 0.8rem */
-    font-weight: 600;
+    padding: 0.4rem 0.7rem; /* Reduce from 0.5rem 0.875rem */
+    border-radius: 5px; /* Reduce from 6px */
+    font-size: 0.7rem; /* Reduce from 0.75rem */
+    font-weight: 500; /* Reduce from 600 for cleaner look */
     transition: all 0.25s ease;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
+    text-transform: none; /* Remove uppercase */
+    letter-spacing: normal; /* Remove 0.3px spacing */
 }
 
 .rt-services-enhanced .rt-service-cta:hover {

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -120,8 +120,8 @@ function add_my_custom_header_html() {
                                 <!-- Services Main (Center Column) -->
                                 <div class="rt-services-main">
                                     <div class="rt-services-header">
-                                        <h3>Treasury Technology Solutions</h3>
-                                        <div class="rt-services-subtitle">Independent guidance for smarter treasury decisions</div>
+                                        <h3>Treasury Technology Selection</h3>
+                                        <div class="rt-services-subtitle">Independent guidance for smarter technology decisions</div>
                                     </div>
 
                                     <div class="rt-services-grid">


### PR DESCRIPTION
## Summary
- update "Services" header content
- reduce spacing and text size in services dropdown styles

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686d9b92ac448331ac13698c5935db56