### PR TITLE
Improve dropdown contrast

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1504,14 +1504,15 @@ body.banner-closed {
     --nav-height: 80px;
     --banner-height: 80px;
     --banner-height-minimized: 60px;
+    /* Increased opacity for better dropdown contrast */
     --dropdown-bg: linear-gradient(135deg,
-        hsla(0, 0%, 100%, .75),
-        hsla(0, 0%, 97%, .8) 50%,
-        hsla(0, 0%, 100%, .75));
+        hsla(0, 0%, 100%, .95),
+        hsla(0, 0%, 97%, .95) 50%,
+        hsla(0, 0%, 100%, .95));
     --dropdown-inner-bg: linear-gradient(135deg,
-        rgba(255, 255, 255, 0.25),
-        rgba(255, 255, 255, 0.2) 50%,
-        rgba(255, 255, 255, 0.25));
+        rgba(255, 255, 255, 0.4),
+        rgba(255, 255, 255, 0.35) 50%,
+        rgba(255, 255, 255, 0.4));
     --dropdown-border-color: rgba(199, 125, 255, .35);
 }
 
@@ -1661,8 +1662,9 @@ body.banner-closed {
 
     /* Enhanced glassmorphism background for better contrast */
     background: var(--dropdown-bg) !important;
-    backdrop-filter: blur(50px) saturate(160%) brightness(1.1) !important;
-    -webkit-backdrop-filter: blur(50px) saturate(160%) brightness(1.1) !important;
+    /* Increase blur for stronger background separation */
+    backdrop-filter: blur(80px) saturate(160%) brightness(1.1) !important;
+    -webkit-backdrop-filter: blur(80px) saturate(160%) brightness(1.1) !important;
     border: 1px solid var(--dropdown-border-color) !important;
     border-top: none !important;
     box-shadow: 0 8px 32px rgba(114, 22, 244, .08), 0 0 0 1px rgba(255, 255, 255, .3) inset !important;
@@ -2520,10 +2522,11 @@ body.banner-closed {
         left: auto !important;
         right: auto !important;
         transform: none !important;
+        /* Slightly more opaque background on mobile */
         background: linear-gradient(135deg,
-            rgba(255, 255, 255, 0.08),
-            rgba(255, 255, 255, 0.04) 50%,
-            rgba(255, 255, 255, 0.08)) !important;
+            rgba(255, 255, 255, 0.2),
+            rgba(255, 255, 255, 0.16) 50%,
+            rgba(255, 255, 255, 0.2)) !important;
         border-radius: 8px !important;
     }
     


### PR DESCRIPTION
## Summary
- update dropdown gradients and blur for higher contrast on header menu

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686d9dc77ea8833193ef9e71146f82bc