### PR TITLE
Adjust spacing for about menu CTA

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -2012,6 +2012,7 @@ body.banner-closed {
     background: linear-gradient(135deg, #8f47f6, #7216f4);
     color: white !important;
     text-decoration: none !important;
+    margin-top: 1.5rem;
     padding: 10px 20px;
     border-radius: 8px;
     font-weight: 600;


### PR DESCRIPTION
## Summary
- add margin on `.rt-team-cta` so the "Meet the Team" button has more space below the founders section

## Testing
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686d9eda18f08331956e8666ea5f39fe