### PR TITLE
Enhance services dropdown spacing

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -3817,9 +3817,9 @@ a[href="#openportalmodal"] {
 /* Enhanced Services Dropdown Container */
 .rt-services-enhanced {
     display: grid;
-    grid-template-columns: 260px 1fr 280px;
-    gap: 2rem;
-    max-width: 1080px;
+    grid-template-columns: 280px 1fr 320px;
+    gap: 3rem;
+    max-width: 1200px;
     margin: 0 auto;
     min-height: 420px; /* Reduced from 480px */
 }
@@ -4169,9 +4169,10 @@ a[href="#openportalmodal"] {
 /* Mobile Responsiveness */
 @media (max-width: 768px) {
     .rt-services-enhanced {
-        grid-template-columns: 1fr;
-        gap: 1.25rem;
+        grid-template-columns: 1fr !important;
+        gap: 1.5rem !important;
         min-height: auto;
+        text-align: center !important;
     }
 
     .rt-services-journey {


### PR DESCRIPTION
## Summary
- widen the services dropdown columns
- increase default gap spacing
- improve mobile spacing

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686da21066788331a2c6688a217f5a8c