### PR TITLE
Refine service menu spacing

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -3879,7 +3879,7 @@ a[href="#openportalmodal"] {
 .rt-services-journey h3 {
     font-size: 1rem;
     font-weight: 600;
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -3978,6 +3978,9 @@ a[href="#openportalmodal"] {
     transition: all 0.25s ease;
     position: relative;
     overflow: hidden;
+    display: flex; /* Allow CTA to align at bottom */
+    flex-direction: column;
+    height: 100%;
 }
 
 .rt-services-enhanced .rt-service-item::before {
@@ -4039,10 +4042,7 @@ a[href="#openportalmodal"] {
 }
 
 .rt-service-features {
-    display: flex;
-    gap: 0.25rem; /* Reduce from 0.375rem */
-    margin-bottom: 0.5rem; /* Consistent spacing below features */
-    flex-wrap: wrap;
+    display: none; /* Hide feature tags for a cleaner layout */
 }
 
 .rt-feature-tag {
@@ -4069,7 +4069,7 @@ a[href="#openportalmodal"] {
     transition: all 0.25s ease;
     text-transform: none; /* Remove uppercase */
     letter-spacing: normal; /* Remove 0.3px spacing */
-    margin-top: 0.5rem; /* Space below feature tags */
+    margin-top: auto; /* Align button to bottom of card */
 }
 
 .rt-services-enhanced .rt-service-cta:hover {
@@ -4094,7 +4094,7 @@ a[href="#openportalmodal"] {
     font-size: 1rem; /* Consistent with other section headers */
     font-weight: 600;
     color: var(--dark-text);
-    margin-bottom: 1.25rem; /* Consistent spacing */
+    margin-bottom: 1.5rem; /* Added extra space below title */
     display: flex;
     align-items: center;
     gap: 0.5rem;

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -131,11 +131,6 @@ function add_my_custom_header_html() {
                                                 <div class="rt-service-title">Treasury Tech Portal</div>
                                             </div>
                                             <div class="rt-service-desc">Access curated treasury tech stack demos and solution overviews from 100+ evaluated vendors.</div>
-                                            <div class="rt-service-features">
-                                                <span class="rt-feature-tag">Demo Library</span>
-                                                <span class="rt-feature-tag">Vendor Comparisons</span>
-                                                <span class="rt-feature-tag">Unbiased Reviews</span>
-                                            </div>
                                             <a href="https://realtreasury.com/treasury-tech-portal/" class="rt-service-cta tpa-btn-ready">
                                                 Request Access →
                                             </a>
@@ -147,11 +142,6 @@ function add_my_custom_header_html() {
                                                 <div class="rt-service-title">Treasury Insights Workshop</div>
                                             </div>
                                             <div class="rt-service-desc">25-minute deep dive sharing real-world insights and best practices from industry experts.</div>
-                                            <div class="rt-service-features">
-                                                <span class="rt-feature-tag">Live Sessions</span>
-                                                <span class="rt-feature-tag">Expert Insights</span>
-                                                <span class="rt-feature-tag">Q&A Included</span>
-                                            </div>
                                             <a href="https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration" target="_blank" class="rt-service-cta">
                                                 Join Workshop →
                                             </a>
@@ -163,11 +153,6 @@ function add_my_custom_header_html() {
                                                 <div class="rt-service-title">Technology Selection</div>
                                             </div>
                                             <div class="rt-service-desc">Expert-guided evaluation to find your ideal treasury platform in 4-6 weeks, not months.</div>
-                                            <div class="rt-service-features">
-                                                <span class="rt-feature-tag">1:1 Guidance</span>
-                                                <span class="rt-feature-tag">Fast Process</span>
-                                                <span class="rt-feature-tag">Independent</span>
-                                            </div>
                                             <a href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2?ismsaljsauthenabled" target="_blank" class="rt-service-cta">
                                                 Start Assessment →
                                             </a>


### PR DESCRIPTION
## Summary
- tweak spacing in service dropdown titles
- hide feature tags for a compact look
- align CTAs at bottom of service cards
- remove feature tag markup from service cards

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686da8c93eac8331a1ae507416d230ea