### PR TITLE
Switch services dropdown stats to testimonials

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -4225,3 +4225,13 @@ a[href="#openportalmodal"] {
         grid-template-columns: 1fr;
     }
 }
+
+/* Services Dropdown Testimonials */
+.rt-stats-grid { display: none !important; }
+.rt-services-testimonials { display: flex !important; flex-direction: column !important; gap: 1.5rem !important; }
+.rt-services-testimonial { background: white !important; padding: 1.25rem !important; border-radius: 10px !important; border-left: 3px solid var(--success-green) !important; box-shadow: 0 4px 12px rgba(16, 185, 129, 0.08) !important; border: 1px solid rgba(16, 185, 129, 0.15) !important; transition: all 0.3s ease !important; }
+.rt-services-testimonial:hover { transform: translateY(-2px) !important; box-shadow: 0 6px 16px rgba(16, 185, 129, 0.12) !important; }
+.rt-services-testimonial-text { font-size: 0.85rem !important; color: var(--gray-text) !important; font-style: italic !important; line-height: 1.5 !important; margin-bottom: 1rem !important; position: relative !important; }
+.rt-services-testimonial-text::before { content: '"' !important; position: absolute !important; left: -0.5rem !important; top: -0.25rem !important; font-size: 1.5rem !important; color: var(--success-green) !important; font-weight: bold !important; opacity: 0.5 !important; }
+.rt-services-testimonial-author { font-size: 0.75rem !important; color: var(--dark-text) !important; font-weight: 600 !important; line-height: 1.3 !important; }
+.rt-services-testimonial-title { font-size: 0.7rem !important; color: var(--gray-text) !important; font-weight: 500 !important; margin-top: 0.25rem !important; }

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -160,26 +160,21 @@ function add_my_custom_header_html() {
                                     </div>
                                 </div>
 
-                                <!-- Stats (Right Column) -->
+                                <!-- Testimonials (Right Column) -->
                                 <div class="rt-services-stats">
                                     <h3>✨ Proven Results</h3>
-                                    <div class="rt-stats-grid">
-                                        <div class="rt-stat-item">
-                                            <div class="rt-stat-number">45+</div>
-                                            <div class="rt-stat-label">Years Combined Experience</div>
+                                    <div class="rt-services-testimonials">
+                                        <div class="rt-services-testimonial">
+                                            <div class="rt-services-testimonial-text">They brought strategic insights we hadn't considered—highlighting key features, gaps, and opportunities.</div>
+                                            <div class="rt-services-testimonial-author">Thi Pham</div>
+                                            <div class="rt-services-testimonial-title">CFO, Vie Management</div>
                                         </div>
-                                        <div class="rt-stat-item">
-                                            <div class="rt-stat-number">100+</div>
-                                            <div class="rt-stat-label">Vendors Evaluated</div>
+
+                                        <div class="rt-services-testimonial">
+                                            <div class="rt-services-testimonial-text">A thoughtful, structured process for selecting technology that actually fits our needs and budget.</div>
+                                            <div class="rt-services-testimonial-author">Tony Vu</div>
+                                            <div class="rt-services-testimonial-title">Treasurer, Broward Health</div>
                                         </div>
-                                        <div class="rt-stat-item">
-                                            <div class="rt-stat-number">4-6</div>
-                                            <div class="rt-stat-label">Weeks to Selection</div>
-                                        </div>
-                                    </div>
-                                    <div class="rt-testimonial">
-                                        <div class="rt-testimonial-text">"They brought strategic insights we hadn't considered—highlighting key features, gaps, and opportunities."</div>
-                                        <div class="rt-testimonial-author">— Thi Pham, CFO, Vie Management</div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- swap stats section in Services dropdown for testimonial quotes
- hide stats styles and add testimonial styles in `shared.css`

## Testing
- `npm run test:ejs` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_686db5c9a7608331871533202a02d47b