### PR TITLE
Make service items clickable

### DIFF
--- a/header/main-menu/JSsnippet/index.html
+++ b/header/main-menu/JSsnippet/index.html
@@ -167,4 +167,14 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    // Make entire service cards clickable
+    document.querySelectorAll('.rt-service-item').forEach(card => {
+        card.addEventListener('click', function(e) {
+            if (!e.target.closest('a')) {
+                const link = card.querySelector('a');
+                if (link) link.click();
+            }
+        });
+    });
+
 });


### PR DESCRIPTION
## Summary
- make entire service cards clickable in Service dropdown

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686db6307c248331a784375404d467f8