### PR TITLE
Fix header spacing in services dropdown

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -3879,7 +3879,7 @@ a[href="#openportalmodal"] {
 .rt-services-journey h3 {
     font-size: 1rem;
     font-weight: 600;
-    margin-bottom: 1.25rem;
+    margin-bottom: 2rem !important;
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -3943,7 +3943,7 @@ a[href="#openportalmodal"] {
 
 .rt-services-header {
     text-align: center;
-    margin-bottom: 1.25rem; /* Reduced from 1.5rem */
+    margin-bottom: 1.75rem !important; /* Increased for consistency */
     padding-bottom: 0.75rem; /* Reduced from 1rem */
     border-bottom: 1px solid rgba(199, 125, 255, 0.2);
 }
@@ -4094,7 +4094,7 @@ a[href="#openportalmodal"] {
     font-size: 1rem; /* Consistent with other section headers */
     font-weight: 600;
     color: var(--dark-text);
-    margin-bottom: 1.5rem; /* Added extra space below title */
+    margin-bottom: 2rem !important; /* Added extra space below title */
     display: flex;
     align-items: center;
     gap: 0.5rem;


### PR DESCRIPTION
## Summary
- adjust margin for the left column title
- adjust margin for the center column title
- adjust margin for the right column title

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686db7ac76508331b9796b2da827d7b9