### PR TITLE
Fix mission heading capitalization

### DIFF
--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -185,7 +185,7 @@ function add_my_custom_header_html() {
                             <div class="rt-about-enhanced">
                                 <!-- Company Story -->
                                 <div class="rt-about-story">
-                                    <h3>Our Mission</h3>
+                                    <h3>OUR MISSION</h3>
                                     <p>Independent. Unbiased. Built for Treasury Teams.</p>
                                     <div class="rt-about-description">
                                         <p>We help finance leaders select treasury technology faster—with confidence, clarity, and zero vendor bias.</p>


### PR DESCRIPTION
## Summary
- display 'OUR MISSION' in uppercase in About dropdown

## Testing
- `grep -n "OUR MISSION" header/main-menu/custom-header.php`

------
https://chatgpt.com/codex/tasks/task_e_686dbe6e496c8331b416375bf72e5827