### PR TITLE
Fix spacing in ABOUT dropdown

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -1894,7 +1894,7 @@ body.banner-closed {
     color: var(--gray-text) !important;
     font-size: 1rem;
     line-height: 1.6;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem !important;
 }
 
 .rt-about-links {


### PR DESCRIPTION
## Summary
- adjust CSS to add margin between ABOUT dropdown paragraphs

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686dc2947288833197516cca2818d22e