### PR TITLE
Fix mobile dropdown nav link color

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -2507,7 +2507,18 @@ body.banner-closed {
         border-color: rgba(199, 125, 255, 0.4) !important;
         color: var(--primary-purple) !important;
     }
-    
+
+    /* Maintain readable text color when menu item is active */
+    .rt-nav-item.active .rt-nav-link {
+        background: rgba(255, 255, 255, 0.9) !important;
+        border-color: rgba(199, 125, 255, 0.4) !important;
+        color: var(--primary-purple) !important;
+    }
+
+    .rt-nav-item.active .rt-nav-link.has-dropdown::after {
+        border-top-color: var(--primary-purple) !important;
+    }
+
     .rt-nav-link.has-dropdown::after {
         border-top-color: var(--dark-text) !important;
     }


### PR DESCRIPTION
## Summary
- keep menu item text visible on mobile when dropdown active

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686e78a4ed288331b86a3ed565fb44e6