### PR TITLE
Fix insights dropdown mobile layout

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -2546,6 +2546,12 @@ body.banner-closed {
         grid-template-columns: 1fr !important;
         gap: 1.5rem !important;
     }
+
+    /* Center explore link image */
+    .rt-explore-link {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
     
     .rt-insights-widget,
     .rt-main-menu-column:last-child {


### PR DESCRIPTION
## Summary
- center the explore image in the Insights dropdown on small screens

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686e8839fca48331a9335cf3d4ad6d2e