### PR TITLE
Add sorting to Treasury Tools admin

### DIFF
--- a/plugins/treasury-tech-portal/includes/class-ttp-admin.php
+++ b/plugins/treasury-tech-portal/includes/class-ttp-admin.php
@@ -28,6 +28,18 @@ class TTP_Admin {
             return;
         }
         $tools = TTP_Data::get_all_tools();
+
+        $sort = isset($_GET['sort']) ? sanitize_text_field($_GET['sort']) : '';
+        if ($sort === 'name') {
+            usort($tools, function($a, $b) {
+                return strcasecmp($a['name'] ?? '', $b['name'] ?? '');
+            });
+        } elseif ($sort === 'category') {
+            usort($tools, function($a, $b) {
+                return strcasecmp($a['category'] ?? '', $b['category'] ?? '');
+            });
+        }
+
         include dirname(__DIR__) . '/templates/admin-page.php';
     }
 

--- a/plugins/treasury-tech-portal/templates/admin-page.php
+++ b/plugins/treasury-tech-portal/templates/admin-page.php
@@ -1,6 +1,16 @@
 <?php if (!defined('ABSPATH')) exit; ?>
 <div class="wrap">
     <h1>Treasury Tools</h1>
+    <?php $current_sort = isset($_GET['sort']) ? sanitize_text_field($_GET['sort']) : ''; ?>
+    <form method="get" style="margin-bottom:10px;">
+        <input type="hidden" name="page" value="treasury-tools">
+        <label for="ttp-sort">Sort By:</label>
+        <select name="sort" id="ttp-sort" onchange="this.form.submit()">
+            <option value="" <?php selected($current_sort, ''); ?>>Default</option>
+            <option value="name" <?php selected($current_sort, 'name'); ?>>Name</option>
+            <option value="category" <?php selected($current_sort, 'category'); ?>>Category</option>
+        </select>
+    </form>
     <?php if (!empty($_GET['updated'])): ?>
         <div class="updated notice"><p>Tool saved.</p></div>
     <?php endif; ?>


### PR DESCRIPTION
## Summary
- allow sorting the Treasury Tools list in the admin
- add dropdown for name/category

## Testing
- `npm run test:ejs` *(fails: Cannot find module 'ejs')*

------
https://chatgpt.com/codex/tasks/task_e_686e887325ec83318e1c0ef7fcb2cb9e