### PR TITLE
Fix video indicator width on portal tools

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -533,12 +533,13 @@
             gap: 16px;
         }
 
-        .treasury-portal .tool-info {
-            display: flex;
-            flex-direction: column;
-            flex-grow: 1;
-            gap: 2px;
-        }
+.treasury-portal .tool-info {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    gap: 2px;
+    align-items: flex-start; /* Avoid full-width buttons */
+}
 
         .treasury-portal .tool-name {
             font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- prevent video demo button from stretching full width of portal tool cards

## Testing
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_686ee753c2dc83319035555eaa45276e