### PR TITLE
Add preconnect hints for fonts

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -14,6 +14,8 @@
     <link rel="canonical" href="https://realtreasury.com">
     
     <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     
     <style>

--- a/insights/2024/cash-tools-explained/index.html
+++ b/insights/2024/cash-tools-explained/index.html
@@ -14,6 +14,8 @@
     <meta property="og:image" content="https://realtreasury.com/images/cash-tools-hero.jpg">
     
     <link rel="canonical" href="https://realtreasury.com/cash-tools-explained">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     
     <style>

--- a/insights/index.html
+++ b/insights/index.html
@@ -9,6 +9,8 @@
     <meta name="description" content="Explore cutting-edge articles and analysis from RealTreasury's experts. Drive your business forward with insights on AI, technology, and market strategy.">
 
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/team/index.html
+++ b/team/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Meet Our Team - Real Treasury</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     
     <style>

--- a/templates/insights/2024/cash-tools-explained/index.html
+++ b/templates/insights/2024/cash-tools-explained/index.html
@@ -14,6 +14,8 @@
     <meta property="og:image" content="https://realtreasury.com/images/cash-tools-hero.jpg">
     
     <link rel="canonical" href="https://realtreasury.com/cash-tools-explained">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     
     <style>

--- a/templates/insights/index.html
+++ b/templates/insights/index.html
@@ -9,6 +9,8 @@
     <meta name="description" content="Explore cutting-edge articles and analysis from RealTreasury's experts. Drive your business forward with insights on AI, technology, and market strategy.">
 
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Treasury Tech Categories | Real Treasury</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
     <style>
         * {


### PR DESCRIPTION
## Summary
- optimize font loading on mobile by adding preconnect links before Google Fonts references

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686f1acc87188331b73d8e9c96db2893