### PR TITLE
Disable fallback overlay when plugin is missing

### DIFF
--- a/assets/php/functions.php
+++ b/assets/php/functions.php
@@ -1485,9 +1485,9 @@ function tpa_theme_modal_trigger() {
             }
 
             if (integrationAttempts >= maxAttempts) {
-                console.log('❌ TPA Plugin not found after', maxAttempts, 'attempts, using fallback');
+                console.log('❌ TPA Plugin not found after', maxAttempts, 'attempts.');
                 integrationComplete = true;
-                useFallbackIntegration();
+                // useFallbackIntegration(); // disabled to prevent fallback overlay
                 return false;
             }
 


### PR DESCRIPTION
## Summary
- update `checkTPAReadiness` so it no longer invokes `useFallbackIntegration`
- keep fallback function for reference
- ensure ejs tests pass

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686fdcf01fdc83319ae2c49b2fb3b6dd