### PR TITLE
Fix video indicator width on vendor cards

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -648,6 +648,7 @@
     color: #6366f1;
     font-weight: 500;
     cursor: pointer;
+    align-self: flex-start; /* prevent full width stretch */
 }
 
         .treasury-portal .tool-card:hover .video-indicator {


### PR DESCRIPTION
## Summary
- prevent the play demo button from stretching to full width

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_686ff1cbf2a88331bbdb9ebdc8bc81ab