### PR TITLE
Fix expand button color on treasury tech market page

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -18,6 +18,7 @@
             --text: #0a0a0a;
             --text-light: #525252;
             --bg: #ffffff;
+            --success: #10b981;
         }
 
         body {


### PR DESCRIPTION
## Summary
- add `--success` color variable to fix expand text visibility

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_687147b6a26c8331ad87ac68a568bb93