### PR TITLE
Fix services CTA alignment

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -4078,6 +4078,7 @@ a[href="#openportalmodal"] {
     text-transform: none;
     letter-spacing: normal;
     margin-top: auto;
+    align-self: flex-start;
 }
 
 .rt-services-enhanced .rt-service-cta:hover {


### PR DESCRIPTION
## Summary
- fix width of CTA buttons in services dropdown

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6871a0e7073c8331be7dbb9ef84a00b0