### PR TITLE
Add abandonment metrics to admin dashboard

### DIFF
--- a/plugins/treasury-portal-access/README.md
+++ b/plugins/treasury-portal-access/README.md
@@ -47,4 +47,4 @@ Once a visitor completes the form they are redirected to your chosen page and ca
 
 ## Attempt Tracking
 
-Version 1.0.7 adds basic tracking for visitors who open the access modal but leave before completing the form. These abandoned attempts are stored in the `portal_access_attempts` database table and displayed on the plugin admin page.
+Version 1.0.8 adds percentage metrics to the admin dashboard. The plugin now shows how many visitors abandon the form versus how many complete it. Abandoned attempts continue to be stored in the `portal_access_attempts` database table.

--- a/plugins/treasury-portal-access/includes/admin-page.php
+++ b/plugins/treasury-portal-access/includes/admin-page.php
@@ -11,6 +11,10 @@ $users = $wpdb->get_results("SELECT * FROM {$table_name} ORDER BY access_granted
 $total_users = is_array($users) ? count($users) : 0;
 $total_attempts = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$attempt_table}");
 
+$total_interactions = $total_users + $total_attempts;
+$completion_rate = $total_interactions > 0 ? round(($total_users / $total_interactions) * 100) : 0;
+$abandon_rate = $total_interactions > 0 ? round(($total_attempts / $total_interactions) * 100) : 0;
+
 // Handle CSV export
 if (isset($_GET['action'], $_GET['_wpnonce']) && $_GET['action'] === 'export' && wp_verify_nonce($_GET['_wpnonce'], 'tpa_export_nonce')) {
     if (current_user_can('manage_options')) {
@@ -74,6 +78,16 @@ if (isset($_GET['action'], $_GET['_wpnonce']) && $_GET['action'] === 'export' &&
         <div style="background: linear-gradient(135deg, #607D8B, #455A64); color: white; padding: 20px; border-radius: 12px; box-shadow: 0 4px 12px rgba(96, 125, 139, 0.3);">
             <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo $total_attempts; ?></h3>
             <p style="margin: 0; opacity: 0.9;">Abandoned Attempts</p>
+        </div>
+
+        <div style="background: linear-gradient(135deg, #2196F3, #1E88E5); color: white; padding: 20px; border-radius: 12px; box-shadow: 0 4px 12px rgba(33, 150, 243, 0.3);">
+            <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo $completion_rate; ?>%</h3>
+            <p style="margin: 0; opacity: 0.9;">Completion Rate</p>
+        </div>
+
+        <div style="background: linear-gradient(135deg, #f44336, #d32f2f); color: white; padding: 20px; border-radius: 12px; box-shadow: 0 4px 12px rgba(244, 67, 54, 0.3);">
+            <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo $abandon_rate; ?>%</h3>
+            <p style="margin: 0; opacity: 0.9;">Abandon Rate</p>
         </div>
     </div>
 

--- a/plugins/treasury-portal-access/treasury-portal-access.php
+++ b/plugins/treasury-portal-access/treasury-portal-access.php
@@ -3,7 +3,7 @@
  * Plugin Name: Treasury Portal Access
  * Plugin URI: https://realtreasury.com
  * Description: Complete portal access control system with Contact Form 7 integration, 6-month persistence, and localStorage backup.
- * Version: 1.0.7
+ * Version: 1.0.8
  * Author: Real Treasury
  * Author URI: https://realtreasury.com
  * License: GPL v2 or later
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('TPA_VERSION', '1.0.7');
+define('TPA_VERSION', '1.0.8');
 define('TPA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('TPA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('TPA_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- add completion/abandon metrics to admin dashboard
- bump Treasury Portal Access plugin to 1.0.8
- document new dashboard metrics in README

## Testing
- `npm run test:ejs`
- `npm run build`
- `php -l plugins/treasury-portal-access/includes/admin-page.php`
- `php -l plugins/treasury-portal-access/treasury-portal-access.php`


------
https://chatgpt.com/codex/tasks/task_e_6874f476b9088331b31fa6d6cb5e0744