### PR TITLE
Fix card alignment on Treasury Tech page

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -159,6 +159,8 @@
         }
 
         .category-card {
+            display: flex;
+            flex-direction: column;
             background: white;
             border-radius: 20px;
             padding: 36px;
@@ -234,7 +236,8 @@
 
         .category-features {
             list-style: none;
-            margin-bottom: 28px;
+            flex-grow: 1;
+            margin-bottom: 24px;
         }
 
         .category-features li {
@@ -267,6 +270,7 @@
             border-radius: 12px;
             padding: 20px;
             border-left: 3px solid var(--primary);
+            margin-bottom: 24px;
         }
 
         .example-label {
@@ -300,7 +304,7 @@
             font-family: inherit;
             position: relative;
             overflow: hidden;
-            margin-top: 16px;
+            margin-top: auto;
             margin-bottom: 16px;
         }
 


### PR DESCRIPTION
## Summary
Align expand buttons across all category cards.

## Changes
- Turn `.category-card` into a flex container
- Let feature lists grow to fill space
- Added bottom spacing to `.category-example`
- Align expand button using `margin-top: auto`

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_687506ee9ef0833189754f5dcfa452bc