### PR TITLE
Fix title height for card alignment

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -220,11 +220,13 @@
             box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
         }
 
-        .category-title {
+.category-title {
             font-size: 28px;
             font-weight: 800;
             margin-bottom: 8px;
             letter-spacing: -0.01em;
+            line-height: 1.2;
+            min-height: 68px;
         }
 
         .category-price {


### PR DESCRIPTION
## Summary
- use consistent height for `.category-title` in tech market page

## Testing
- `npm run test:ejs`
- `node test/ejs-test.js`


------
https://chatgpt.com/codex/tasks/task_e_68750f8f5c70833190490def56f55ca3