### PR TITLE
Add weekly abandon metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The repository includes the **Treasury Portal Access** plugin (`plugins/treasury
 
 As of plugin version 1.0.7 the portal records when a visitor opens the access modal but leaves without submitting the form. These entries appear on the Portal Access admin screen so you can gauge interest in the portal.
 
+Version 1.0.9 adds weekly metrics showing the abandonment rate for both the current and previous week.
+
 ## Clean Media URLs Plugin
 
 The repository also includes the **Clean Media URLs** plugin (`plugins/clean-media-urls`). Activate it in WordPress to automatically sanitize media filenames so URLs contain only lowercase letters, numbers, and hyphens.

--- a/plugins/treasury-portal-access/README.md
+++ b/plugins/treasury-portal-access/README.md
@@ -48,3 +48,5 @@ Once a visitor completes the form they are redirected to your chosen page and ca
 ## Attempt Tracking
 
 Version 1.0.8 adds percentage metrics to the admin dashboard. The plugin now shows how many visitors abandon the form versus how many complete it. Abandoned attempts continue to be stored in the `portal_access_attempts` database table.
+
+Version 1.0.9 extends these stats with weekly abandonment rates for the current and previous week.

--- a/plugins/treasury-portal-access/includes/admin-page.php
+++ b/plugins/treasury-portal-access/includes/admin-page.php
@@ -15,6 +15,17 @@ $total_interactions = $total_users + $total_attempts;
 $completion_rate = $total_interactions > 0 ? round(($total_users / $total_interactions) * 100) : 0;
 $abandon_rate = $total_interactions > 0 ? round(($total_attempts / $total_interactions) * 100) : 0;
 
+// Weekly abandonment rates
+$current_attempts = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$attempt_table} WHERE attempted_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)");
+$current_completions = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table_name} WHERE access_granted >= DATE_SUB(NOW(), INTERVAL 7 DAY)");
+$current_total = $current_attempts + $current_completions;
+$current_abandon_rate = $current_total > 0 ? round(($current_attempts / $current_total) * 100) : 0;
+
+$previous_attempts = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$attempt_table} WHERE attempted_at >= DATE_SUB(NOW(), INTERVAL 14 DAY) AND attempted_at < DATE_SUB(NOW(), INTERVAL 7 DAY)");
+$previous_completions = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table_name} WHERE access_granted >= DATE_SUB(NOW(), INTERVAL 14 DAY) AND access_granted < DATE_SUB(NOW(), INTERVAL 7 DAY)");
+$previous_total = $previous_attempts + $previous_completions;
+$previous_abandon_rate = $previous_total > 0 ? round(($previous_attempts / $previous_total) * 100) : 0;
+
 // Handle CSV export
 if (isset($_GET['action'], $_GET['_wpnonce']) && $_GET['action'] === 'export' && wp_verify_nonce($_GET['_wpnonce'], 'tpa_export_nonce')) {
     if (current_user_can('manage_options')) {
@@ -77,8 +88,9 @@ if (isset($_GET['action'], $_GET['_wpnonce']) && $_GET['action'] === 'export' &&
         </div>
 
         <div style="background: linear-gradient(135deg, #f44336, #d32f2f); color: white; padding: 20px; border-radius: 12px; box-shadow: 0 4px 12px rgba(244, 67, 54, 0.3);">
-            <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo $abandon_rate; ?>%</h3>
-            <p style="margin: 0; opacity: 0.9;">Abandon Rate</p>
+            <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo $current_abandon_rate; ?>%</h3>
+            <p style="margin: 0; opacity: 0.9;">Abandon Rate (This Week)</p>
+            <p style="margin: 0; opacity: 0.7; font-size: 0.9rem;">Last Week: <?php echo $previous_abandon_rate; ?>%</p>
         </div>
     </div>
 

--- a/plugins/treasury-portal-access/treasury-portal-access.php
+++ b/plugins/treasury-portal-access/treasury-portal-access.php
@@ -3,7 +3,7 @@
  * Plugin Name: Treasury Portal Access
  * Plugin URI: https://realtreasury.com
  * Description: Complete portal access control system with Contact Form 7 integration, 6-month persistence, and localStorage backup.
- * Version: 1.0.8
+ * Version: 1.0.9
  * Author: Real Treasury
  * Author URI: https://realtreasury.com
  * License: GPL v2 or later
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('TPA_VERSION', '1.0.8');
+define('TPA_VERSION', '1.0.9');
 define('TPA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('TPA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('TPA_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- add weekly abandonment rate metrics on admin dashboard
- bump Treasury Portal Access version to 1.0.9
- document the new feature in both READMEs

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68751562a27083318df974680766aa17