### PR TITLE
Add weekly portal user stats

### DIFF
--- a/plugins/treasury-portal-access/README.md
+++ b/plugins/treasury-portal-access/README.md
@@ -50,3 +50,5 @@ Once a visitor completes the form they are redirected to your chosen page and ca
 Version 1.0.8 adds percentage metrics to the admin dashboard. The plugin now shows how many visitors abandon the form versus how many complete it. Abandoned attempts continue to be stored in the `portal_access_attempts` database table.
 
 Version 1.0.9 extends these stats with weekly abandonment rates for the current and previous week.
+
+Version 1.0.10 displays weekly user counts for the current and prior week.

--- a/plugins/treasury-portal-access/includes/admin-page.php
+++ b/plugins/treasury-portal-access/includes/admin-page.php
@@ -26,6 +26,10 @@ $previous_completions = (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table_name}
 $previous_total = $previous_attempts + $previous_completions;
 $previous_abandon_rate = $previous_total > 0 ? round(($previous_attempts / $previous_total) * 100) : 0;
 
+// Weekly user counts
+$current_week_users = $current_completions;
+$previous_week_users = $previous_completions;
+
 // Handle CSV export
 if (isset($_GET['action'], $_GET['_wpnonce']) && $_GET['action'] === 'export' && wp_verify_nonce($_GET['_wpnonce'], 'tpa_export_nonce')) {
     if (current_user_can('manage_options')) {
@@ -70,9 +74,9 @@ if (isset($_GET['action'], $_GET['_wpnonce']) && $_GET['action'] === 'export' &&
         </div>
         
         <div style="background: linear-gradient(135deg, #4CAF50, #45a049); color: white; padding: 20px; border-radius: 12px; box-shadow: 0 4px 12px rgba(76, 175, 80, 0.3);">
-            <?php $recent_users = $wpdb->get_var("SELECT COUNT(*) FROM {$table_name} WHERE access_granted >= DATE_SUB(NOW(), INTERVAL 7 DAY)"); ?>
-            <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo (int) $recent_users; ?></h3>
-            <p style="margin: 0; opacity: 0.9;">This Week</p>
+            <h3 style="margin: 0 0 10px; font-size: 2rem; color: white;"><?php echo (int) $current_week_users; ?></h3>
+            <p style="margin: 0; opacity: 0.9;">Accesses (This Week)</p>
+            <p style="margin: 0; opacity: 0.7; font-size: 0.9rem;">Last Week: <?php echo (int) $previous_week_users; ?></p>
         </div>
         
         <!-- Removed Terms Acceptance and Days Access metrics -->

--- a/plugins/treasury-portal-access/treasury-portal-access.php
+++ b/plugins/treasury-portal-access/treasury-portal-access.php
@@ -3,7 +3,7 @@
  * Plugin Name: Treasury Portal Access
  * Plugin URI: https://realtreasury.com
  * Description: Complete portal access control system with Contact Form 7 integration, 6-month persistence, and localStorage backup.
- * Version: 1.0.9
+ * Version: 1.0.10
  * Author: Real Treasury
  * Author URI: https://realtreasury.com
  * License: GPL v2 or later
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('TPA_VERSION', '1.0.9');
+define('TPA_VERSION', '1.0.10');
 define('TPA_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('TPA_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('TPA_PLUGIN_FILE', __FILE__);


### PR DESCRIPTION
## Summary
- show this and last week's access counts in admin
- bump portal plugin version to 1.0.10

## Testing
- `npm run test:ejs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687518f2842083319db2e390a9d7363f