### PR TITLE
Fix duplicate close button in Shortlist sidebar

### DIFF
--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -132,9 +132,7 @@ if (!defined("ABSPATH")) exit;
         <div class="shortlist-menu-header">
             <div></div>
             <h3 class="shortlist-menu-title">Shortlist</h3>
-            <button class="menu-toggle" id="shortlistMenuToggle" aria-label="Open shortlist menu" title="Shortlist">
-                <span class="icon"></span>
-            </button>
+            <div style="width: 36px;"></div>
         </div>
         <div class="shortlist-menu-content">
             <div class="shortlist-section">


### PR DESCRIPTION
## Summary
- adjust shortlist sidebar markup to remove duplicate close button

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_687561684c108331b72881e0506c14e8