### PR TITLE
Fix shortlist toggle active style

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -1669,8 +1669,8 @@
         }
 
         .treasury-portal .external-shortlist-toggle.active .icon {
-            background: rgba(114,22,244,0.9);
-            color: #7216f4;
+            background: rgba(255,255,255,0.7);
+            color: inherit;
         }
 
         .treasury-portal .external-shortlist-toggle.active .icon::before {


### PR DESCRIPTION
## Summary
- use the default icon background color for active shortlist toggle
- allow text color to inherit from parent
- run build after change

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68765d41e49883318d86503180563a1c