### PR TITLE
Refactor ownership hero and add share script

### DIFF
--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -52,6 +52,136 @@
     box-sizing: border-box !important;
 }
 
+/* Insight Hero Styles */
+.insight-hero {
+    padding: 60px 20px;
+    background: linear-gradient(135deg, #f8f8f8, #ffffff);
+    text-align: center;
+}
+
+.insight-hero h1 {
+    font-size: 2.5rem;
+    font-weight: 800;
+    color: var(--dark-text);
+    margin-bottom: 1rem;
+}
+
+.insight-hero .subtitle {
+    font-size: 1.25rem;
+    color: var(--gray-text);
+    margin-bottom: 1.5rem;
+}
+
+.insight-hero .cta-button {
+    margin-top: 0.5rem;
+}
+
+/* Share Button Styles */
+.share-buttons {
+    margin-top: 30px;
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.share-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 20px;
+    background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(248,248,248,0.98));
+    backdrop-filter: blur(20px) saturate(130%);
+    -webkit-backdrop-filter: blur(20px) saturate(130%);
+    text-decoration: none;
+    border-radius: 8px;
+    border: 1px solid rgba(199,125,255,0.2);
+    box-shadow: 0 4px 16px rgba(114,22,244,0.08);
+    transition: all 0.3s cubic-bezier(0.4,0,0.2,1);
+    font-weight: 500;
+    font-size: 0.9rem;
+    min-width: 120px;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+}
+
+.share-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent);
+    transition: left 0.5s;
+}
+
+.share-btn:hover::before {
+    left: 100%;
+}
+
+.share-btn.linkedin { color: #0077B5; border-color: rgba(0,119,181,0.2); }
+.share-btn.linkedin:hover {
+    background: linear-gradient(135deg, #0077B5, #005885);
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0,119,181,0.25);
+    border-color: #0077B5;
+    text-decoration: none;
+}
+
+.share-btn.x-twitter { color: #000; border-color: rgba(0,0,0,0.15); }
+.share-btn.x-twitter:hover {
+    background: linear-gradient(135deg, #000, #1a1a1a);
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(0,0,0,0.25);
+    border-color: #000;
+    text-decoration: none;
+}
+
+.share-btn.email { color: #6B7280; border-color: rgba(107,114,128,0.2); }
+.share-btn.email:hover {
+    background: linear-gradient(135deg, #6B7280, #4B5563);
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(107,114,128,0.25);
+    border-color: #6B7280;
+    text-decoration: none;
+}
+
+.share-btn.copy-link { color: var(--primary-purple); border-color: rgba(114,22,244,0.2); }
+.share-btn.copy-link:hover {
+    background: linear-gradient(135deg, var(--primary-purple), var(--secondary-purple));
+    color: #fff;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(114,22,244,0.25);
+    border-color: var(--primary-purple);
+    text-decoration: none;
+}
+
+.share-btn.copied {
+    background: linear-gradient(135deg, #10B981, #059669) !important;
+    color: #fff !important;
+    border-color: #10B981 !important;
+}
+
+.share-icon {
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.share-divider {
+    margin: 0 20px;
+    font-size: 0.8rem;
+    color: var(--gray-text);
+    opacity: 0.6;
+    font-weight: 400;
+}
+
 .modal.show, .tpa-modal.show {
     opacity: 1 !important;
     visibility: visible !important;

--- a/insights/2024/cash-tools-explained/index.html
+++ b/insights/2024/cash-tools-explained/index.html
@@ -459,6 +459,7 @@
 
 
 
+
 <section class="insight-hero">
   
     <div class="container">

--- a/insights/2024/cre-treasury-tech/index.html
+++ b/insights/2024/cre-treasury-tech/index.html
@@ -632,6 +632,7 @@
 
 
 
+
 <section class="insight-hero">
   
     

--- a/insights/2024/payment-networks-explained/index.html
+++ b/insights/2024/payment-networks-explained/index.html
@@ -377,6 +377,7 @@
 
 
 
+
 <section class="insight-hero">
   
     <div class="container">

--- a/insights/2024/pre-treasury-explained/index.html
+++ b/insights/2024/pre-treasury-explained/index.html
@@ -307,6 +307,7 @@
 
 
 
+
 <section class="insight-hero">
   
     

--- a/insights/2024/real-estate-ownership-explained/index.html
+++ b/insights/2024/real-estate-ownership-explained/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Real Estate Ownership Explained: Types, Benefits & Smart Management | Real Treasury</title>
-    <meta name="description" content="Learn the different types of real estate ownership, their benefits, and how modern treasury management systems help optimize property investments. Complete guide from Real Treasury experts.">
+    <title>Real Estate Ownership Guide: Types, Benefits & Management Tips | Real Treasury</title>
+    <meta name="description" content="Step-by-step tutorial on property ownership structures and proven management strategies. Download the free Real Treasury Ownership Guide to master real estate investing.">
     <meta name="keywords" content="real estate ownership, property ownership types, real estate investment, treasury management, property portfolio optimization">
     <meta name="author" content="Real Treasury">
     
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Real Estate Ownership Explained: Types, Benefits & Smart Management">
-    <meta property="og:description" content="Complete guide to real estate ownership types and how modern treasury systems optimize property investments.">
+    <meta property="og:title" content="Real Estate Ownership Guide: Types, Benefits & Management Tips">
+    <meta property="og:description" content="Free tutorial covering property ownership structures and modern management approaches for investors.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://realtreasury.com/real-estate-ownership-explained">
     <meta property="og:site_name" content="Real Treasury">
@@ -19,9 +19,9 @@
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Real Estate Ownership Explained: Types, Benefits & Smart Management",
-        "description": "Complete guide to real estate ownership types and modern management approaches",
+        "@type": "HowTo",
+        "headline": "Real Estate Ownership Guide: Types, Benefits & Management Tips",
+        "description": "Step-by-step tutorial on property ownership structures and modern management approaches",
         "author": {
             "@type": "Organization",
             "name": "Real Treasury"
@@ -345,25 +345,20 @@
 <body>
     <!-- Hero Section -->
     
-    
+
 
 
 
 
 <section class="insight-hero">
   
-    
+    <div class="container">
       
-        <div class="hero-content">
-            <h1>Real Estate Ownership Explained</h1>
-            <p class="subtitle">Understand the different types of property ownership and how to manage them effectively</p>
-            <div class="hero-cta">
-                <button class="cta-button" onclick="openLeadModal()">Get Ownership Guide</button>
-                <a href="#ownership-types" class="cta-button secondary">Learn More</a>
-            </div>
-        </div>
-    
-    
+        <h1>Real Estate Ownership Guide</h1>
+        <p class="subtitle">Understand the different types of property ownership and how to manage them effectively</p>
+        <a href="#leadModal" class="cta-button" onclick="openLeadModal()">Get Ownership Guide</a>
+      
+    </div>
   
 </section>
 
@@ -617,13 +612,79 @@
             });
         }, observerOptions);
 
-        document.querySelectorAll('.glass-card').forEach(card => {
-            card.style.opacity = '0';
-            card.style.transform = 'translateY(30px)';
-            card.style.transition = 'all 0.6s ease';
-            observer.observe(card);
-        });
+    document.querySelectorAll('.glass-card').forEach(card => {
+        card.style.opacity = '0';
+        card.style.transform = 'translateY(30px)';
+        card.style.transition = 'all 0.6s ease';
+        observer.observe(card);
+    });
     </script>
+    <script>
+function shareOnLinkedIn() {
+  const url = encodeURIComponent(window.location.href);
+  const title = encodeURIComponent(document.title);
+  const linkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${url}&title=${title}`;
+  window.open(linkedIn, '_blank', 'width=600,height=400');
+}
+
+function shareOnX() {
+  const url = encodeURIComponent(window.location.href);
+  const text = encodeURIComponent(document.title);
+  const hashtags = encodeURIComponent('RealTreasury');
+  const xUrl = `https://twitter.com/intent/tweet?url=${url}&text=${text}&hashtags=${hashtags}`;
+  window.open(xUrl, '_blank', 'width=600,height=400');
+}
+
+function shareViaEmail() {
+  const subject = encodeURIComponent(document.title);
+  const body = encodeURIComponent(`Check out this article: ${window.location.href}`);
+  window.location.href = `mailto:?subject=${subject}&body=${body}`;
+}
+
+function copyLink(button) {
+  const url = window.location.href;
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(url).then(() => {
+      showCopySuccess(button);
+    }).catch(() => {
+      fallbackCopyTextToClipboard(url, button);
+    });
+  } else {
+    fallbackCopyTextToClipboard(url, button);
+  }
+}
+
+function fallbackCopyTextToClipboard(text, button) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'fixed';
+  textArea.style.top = 0;
+  textArea.style.left = 0;
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    document.execCommand('copy');
+    showCopySuccess(button);
+  } catch (err) {
+    console.error('Unable to copy', err);
+  }
+  document.body.removeChild(textArea);
+}
+
+function showCopySuccess(button) {
+  if (!button) return;
+  const originalText = button.querySelector('.copy-text').textContent;
+  const originalClass = button.className;
+  button.classList.add('copied');
+  button.querySelector('.copy-text').textContent = 'Copied!';
+  setTimeout(() => {
+    button.className = originalClass;
+    button.querySelector('.copy-text').textContent = originalText;
+  }, 2000);
+}
+</script>
+
 
 </body>
 </html>

--- a/insights/2024/real-treasury-explained/index.html
+++ b/insights/2024/real-treasury-explained/index.html
@@ -647,6 +647,7 @@
 
 
 
+
 <section class="insight-hero">
   
     <div class="container">

--- a/insights/2024/tms-data-flow/index.html
+++ b/insights/2024/tms-data-flow/index.html
@@ -872,6 +872,7 @@
 
 
 
+
 <section class="insight-hero">
   
     

--- a/templates/insights/2024/real-estate-ownership-explained/index.html
+++ b/templates/insights/2024/real-estate-ownership-explained/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Real Estate Ownership Explained: Types, Benefits & Smart Management | Real Treasury</title>
-    <meta name="description" content="Learn the different types of real estate ownership, their benefits, and how modern treasury management systems help optimize property investments. Complete guide from Real Treasury experts.">
+    <title>Real Estate Ownership Guide: Types, Benefits & Management Tips | Real Treasury</title>
+    <meta name="description" content="Step-by-step tutorial on property ownership structures and proven management strategies. Download the free Real Treasury Ownership Guide to master real estate investing.">
     <meta name="keywords" content="real estate ownership, property ownership types, real estate investment, treasury management, property portfolio optimization">
     <meta name="author" content="Real Treasury">
     
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Real Estate Ownership Explained: Types, Benefits & Smart Management">
-    <meta property="og:description" content="Complete guide to real estate ownership types and how modern treasury systems optimize property investments.">
+    <meta property="og:title" content="Real Estate Ownership Guide: Types, Benefits & Management Tips">
+    <meta property="og:description" content="Free tutorial covering property ownership structures and modern management approaches for investors.">
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://realtreasury.com/real-estate-ownership-explained">
     <meta property="og:site_name" content="Real Treasury">
@@ -19,9 +19,9 @@
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Real Estate Ownership Explained: Types, Benefits & Smart Management",
-        "description": "Complete guide to real estate ownership types and modern management approaches",
+        "@type": "HowTo",
+        "headline": "Real Estate Ownership Guide: Types, Benefits & Management Tips",
+        "description": "Step-by-step tutorial on property ownership structures and modern management approaches",
         "author": {
             "@type": "Organization",
             "name": "Real Treasury"
@@ -344,17 +344,12 @@
 </head>
 <body>
     <!-- Hero Section -->
-    <% heroContent = `
-        <div class="hero-content">
-            <h1>Real Estate Ownership Explained</h1>
-            <p class="subtitle">Understand the different types of property ownership and how to manage them effectively</p>
-            <div class="hero-cta">
-                <button class="cta-button" onclick="openLeadModal()">Get Ownership Guide</button>
-                <a href="#ownership-types" class="cta-button secondary">Learn More</a>
-            </div>
-        </div>
-    ` %>
-    <%- include('/partials/insight-hero.html', { heroContent: heroContent, containerClass: false }) %>
+    <%- include('/partials/insight-hero.html', {
+        title: 'Real Estate Ownership Guide',
+        subtitle: 'Understand the different types of property ownership and how to manage them effectively',
+        cta: { href: '#leadModal', text: 'Get Ownership Guide' },
+        ctaOnclick: 'openLeadModal()'
+    }) %>
 
     <!-- Types of Real Estate Ownership -->
     <section id="ownership-types" class="content-section">
@@ -605,13 +600,14 @@
             });
         }, observerOptions);
 
-        document.querySelectorAll('.glass-card').forEach(card => {
-            card.style.opacity = '0';
-            card.style.transform = 'translateY(30px)';
-            card.style.transition = 'all 0.6s ease';
-            observer.observe(card);
-        });
+    document.querySelectorAll('.glass-card').forEach(card => {
+        card.style.opacity = '0';
+        card.style.transform = 'translateY(30px)';
+        card.style.transition = 'all 0.6s ease';
+        observer.observe(card);
+    });
     </script>
+    <%- include('/partials/share-script.html') %>
 
 </body>
 </html>

--- a/templates/partials/insight-hero.html
+++ b/templates/partials/insight-hero.html
@@ -1,6 +1,7 @@
 <% var cls = typeof containerClass === 'undefined' ? 'container' : containerClass; %>
 <% var heroContent = typeof heroContent === 'undefined' ? '' : heroContent; %>
 <% var cta = typeof cta === 'undefined' ? null : cta; %>
+<% var ctaOnclick = typeof ctaOnclick === 'undefined' ? '' : ctaOnclick; %>
 <% var title = typeof title === 'undefined' ? '' : title; %>
 <% var subtitle = typeof subtitle === 'undefined' ? '' : subtitle; %>
 <section class="insight-hero">
@@ -15,7 +16,7 @@
       <% } else { %>
         <h1><%= title %></h1>
         <% if (subtitle) { %><p class="subtitle"><%= subtitle %></p><% } %>
-        <% if (cta) { %><a href="<%= cta.href %>" class="cta-button"><%= cta.text %></a><% } %>
+        <% if (cta) { %><a href="<%= cta.href %>" class="cta-button"<% if (ctaOnclick) { %> onclick="<%= ctaOnclick %>"<% } %>><%= cta.text %></a><% } %>
       <% } %>
     </div>
   <% } %>

--- a/templates/partials/share-script.html
+++ b/templates/partials/share-script.html
@@ -1,0 +1,65 @@
+<script>
+function shareOnLinkedIn() {
+  const url = encodeURIComponent(window.location.href);
+  const title = encodeURIComponent(document.title);
+  const linkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${url}&title=${title}`;
+  window.open(linkedIn, '_blank', 'width=600,height=400');
+}
+
+function shareOnX() {
+  const url = encodeURIComponent(window.location.href);
+  const text = encodeURIComponent(document.title);
+  const hashtags = encodeURIComponent('RealTreasury');
+  const xUrl = `https://twitter.com/intent/tweet?url=${url}&text=${text}&hashtags=${hashtags}`;
+  window.open(xUrl, '_blank', 'width=600,height=400');
+}
+
+function shareViaEmail() {
+  const subject = encodeURIComponent(document.title);
+  const body = encodeURIComponent(`Check out this article: ${window.location.href}`);
+  window.location.href = `mailto:?subject=${subject}&body=${body}`;
+}
+
+function copyLink(button) {
+  const url = window.location.href;
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(url).then(() => {
+      showCopySuccess(button);
+    }).catch(() => {
+      fallbackCopyTextToClipboard(url, button);
+    });
+  } else {
+    fallbackCopyTextToClipboard(url, button);
+  }
+}
+
+function fallbackCopyTextToClipboard(text, button) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'fixed';
+  textArea.style.top = 0;
+  textArea.style.left = 0;
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    document.execCommand('copy');
+    showCopySuccess(button);
+  } catch (err) {
+    console.error('Unable to copy', err);
+  }
+  document.body.removeChild(textArea);
+}
+
+function showCopySuccess(button) {
+  if (!button) return;
+  const originalText = button.querySelector('.copy-text').textContent;
+  const originalClass = button.className;
+  button.classList.add('copied');
+  button.querySelector('.copy-text').textContent = 'Copied!';
+  setTimeout(() => {
+    button.className = originalClass;
+    button.querySelector('.copy-text').textContent = originalText;
+  }, 2000);
+}
+</script>


### PR DESCRIPTION
## Summary
- use `insight-hero.html` partial for the real estate ownership article
- update metadata for a guide style article
- support optional hero CTA `onclick` handling
- add partial share script for LinkedIn, X, email, and copy link
- style insight heroes and share buttons in `shared.css`
- rebuild insight HTML

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_687666a3a65c8331a069821216d1e012