### PR TITLE
Add homepage stats partial

### DIFF
--- a/templates/partials/homepage-stats.ejs
+++ b/templates/partials/homepage-stats.ejs
@@ -1,0 +1,17 @@
+<% var homepageStats = [
+  { number: '4-6 Weeks', label: 'Average Selection Time' },
+  { number: '100+',       label: 'Vendors Evaluated' },
+  { number: '100%',       label: 'Independent & Unbiased' },
+  { number: '45+',        label: 'Years Experience' }
+]; %>
+
+<% if (homepageStats && homepageStats.length) { %>
+<div class="hero-stats">
+  <% homepageStats.forEach(function(m){ %>
+    <div class="stat-card">
+      <span class="stat-number"><%= m.number %></span>
+      <span class="stat-label"><%= m.label %></span>
+    </div>
+  <% }); %>
+</div>
+<% } %>


### PR DESCRIPTION
## Summary
- add new partial `homepage-stats.ejs` with official metrics and optional markup for `.hero-stats`

## Testing
- `npm run test:ejs`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68767986c7888331bbd3fe0b3137b785