### PR TITLE
Integrate shared homepage metrics

### DIFF
--- a/templates/insights/2024/cash-tools-explained/index.html
+++ b/templates/insights/2024/cash-tools-explained/index.html
@@ -476,6 +476,7 @@
 <body>
     <div class="reading-progress"></div>
     <div class="page-container">
+    <%- include('/partials/homepage-stats.ejs') %>
     <!-- Schema.org structured data for SEO -->
     <script type="application/ld+json">
     {
@@ -514,7 +515,8 @@
             '💻 Technology Guide',
             '💡 Expert Insights'
         ],
-        cta: { href: '#get-started', text: 'Get Your Free Treasury Analysis' }
+        cta: { href: '#get-started', text: 'Get Your Free Treasury Analysis' },
+        metrics: homepageStats
     }) %>
                     <ul class="tool-features">
                         <li>Global cash position dashboard</li>
@@ -590,22 +592,12 @@
                 <p style="color: rgba(255,255,255,0.9);">See how businesses leverage cash tools to achieve measurable financial improvements</p>
             </div>
             <div class="stats-grid">
+                <% homepageStats.forEach(function(m){ %>
                 <div class="stat-item">
-                    <h3>25%</h3>
-                    <p>Average improvement in cash conversion cycle</p>
+                    <span class="stat-number"><%= m.number %></span>
+                    <span class="stat-label"><%= m.label %></span>
                 </div>
-                <div class="stat-item">
-                    <h3>40%</h3>
-                    <p>Reduction in manual treasury processes</p>
-                </div>
-                <div class="stat-item">
-                    <h3>15%</h3>
-                    <p>Increase in investment returns on excess cash</p>
-                </div>
-                <div class="stat-item">
-                    <h3>99.8%</h3>
-                    <p>Forecast accuracy with advanced tools</p>
-                </div>
+                <% }); %>
             </div>
         </div>
     </section>

--- a/templates/insights/2024/cloud-services-today/index.html
+++ b/templates/insights/2024/cloud-services-today/index.html
@@ -662,13 +662,15 @@
 </head>
 <body>
     <div class="reading-progress"></div>
-    
+
     <article class="article-container">
+        <%- include('/partials/homepage-stats.ejs') %>
         <%- include('/partials/insight-hero.html', {
             title: 'Treasury Marketplace Part 1: Infrastructure Revolution',
             subtitle: 'The corporate treasury landscape is undergoing its most dramatic transformation in decades. Discover how <em>treasury marketplaces</em> are fundamentally reshaping financial infrastructure, unlocking unprecedented efficiency gains, and creating new strategic advantages for forward-thinking organizations.',
             meta: ['📅 January 15, 2025', '⏱️ 12 min read', '📊 Treasury Strategy', '🎯 Part 1 of 3'],
-            cta: { href: '#insightForm', text: 'Get Part 2 + ROI Calculator' }
+            cta: { href: '#insightForm', text: 'Get Part 2 + ROI Calculator' },
+            metrics: homepageStats
         }) %>
 
         <!-- Introduction -->
@@ -709,22 +711,12 @@
             </p>
 
             <div class="stats-grid">
+                <% homepageStats.forEach(function(m){ %>
                 <div class="stat-card">
-                    <span class="stat-number">78%</span>
-                    <span class="stat-label">Manual Process Dependency Across Treasury Operations</span>
+                    <span class="stat-number"><%= m.number %></span>
+                    <span class="stat-label"><%= m.label %></span>
                 </div>
-                <div class="stat-card">
-                    <span class="stat-number">18+</span>
-                    <span class="stat-label">Average Banking Relationships Per Enterprise</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number">45%</span>
-                    <span class="stat-label">Time Spent on Data Reconciliation</span>
-                </div>
-                <div class="stat-card">
-                    <span class="stat-number">$3.2M</span>
-                    <span class="stat-label">Annual Inefficiency Cost (Fortune 500)</span>
-                </div>
+                <% }); %>
             </div>
 
             <p class="content-text">

--- a/templates/insights/2024/cre-treasury-tech/index.html
+++ b/templates/insights/2024/cre-treasury-tech/index.html
@@ -624,8 +624,9 @@
 </head>
 <body>
     <div class="reading-progress"></div>
-    
+
     <div class="page-container">
+        <%- include('/partials/homepage-stats.ejs') %>
         <!-- Hero Section -->
 
 <%- include('/partials/insight-hero-v2.html', {
@@ -633,12 +634,7 @@
     title: 'Treasury Technology for Real Estate Funds',
     subtitle: 'Discover how advanced treasury technology transforms real estate fund operations through <em>intelligent automation</em>, integrated payment systems, and strategic data analytics. Gain competitive advantages with modern treasury infrastructure designed for the unique challenges of real estate sponsors and fund managers.',
     meta: ['🏢 Real Estate Technology', '⏱️ 10 min read', '💡 Expert Insights', '🎯 Fund Management'],
-    metrics: [
-        { number: '65%', label: 'Time Savings with Automation' },
-        { number: '40+', label: 'Banking Relationships Managed' },
-        { number: '$3B+', label: 'Assets Under Management' },
-        { number: '90%', label: 'Faster Monthly Close' }
-    ],
+    metrics: homepageStats,
     cta: { text: 'Get Assessment Tool + Consultation', href: '#techAssessmentForm' }
 }) %>
         <!-- Introduction -->

--- a/templates/insights/2024/real-treasury-explained/index.html
+++ b/templates/insights/2024/real-treasury-explained/index.html
@@ -640,16 +640,13 @@
     </style>
 </head>
 <body>
+    <%- include('/partials/homepage-stats.ejs') %>
     <!-- Hero Section -->
     <%- include('/partials/article-hero.html', {
         title: 'Transform Your Treasury Operations in 30 Days',
         subtitle: "Join 500+ finance leaders using Real Treasury's AI-powered platform to optimize cash flow, reduce costs, and unlock millions in working capital.",
         meta: ['July 15, 2025', '5 min read', 'Expert Insights', 'SOC 2 Certified'],
-        metrics: [
-          { number: '$2.3M', label: 'Avg. Annual Savings' },
-          { number: '85%', label: 'Time Reduction' },
-          { number: '30', label: 'Days to ROI' }
-        ],
+        metrics: homepageStats,
         cta: [
           { href: 'https://realtreasury.com/treasury-tech-portal/', text: 'Access Portal', class: 'btn-primary tpa-btn-ready' },
           { href: '#roi-calculator', text: '💰 Calculate Your Savings', class: 'btn-secondary' }

--- a/templates/insights/2025/tms-selection-guide/index.html
+++ b/templates/insights/2025/tms-selection-guide/index.html
@@ -437,6 +437,7 @@
 
 <body>
     <!-- Hero Section -->
+    <%- include('/partials/homepage-stats.ejs') %>
     <% heroContent = `
         <div class="article-meta">
             <span>📅 January 1, 2025</span>
@@ -475,28 +476,18 @@
             </a>
         </div>
     ` %>
-    <%- include('/partials/insight-hero.html', { heroContent: heroContent }) %>
+    <%- include('/partials/insight-hero.html', { heroContent: heroContent, metrics: homepageStats }) %>
 
     <!-- Stats Section -->
     <section class="stats-container section-alt">
         <div class="container">
             <div class="grid grid-4">
+                <% homepageStats.forEach(function(m){ %>
                 <div class="stat-item">
-                    <span class="stat-number">87%</span>
-                    <span class="stat-label">Cost Reduction Achieved</span>
+                    <span class="stat-number"><%= m.number %></span>
+                    <span class="stat-label"><%= m.label %></span>
                 </div>
-                <div class="stat-item">
-                    <span class="stat-number">50+</span>
-                    <span class="stat-label">TMS Implementations</span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-number">$2M+</span>
-                    <span class="stat-label">Average Savings</span>
-                </div>
-                <div class="stat-item">
-                    <span class="stat-number">6 Months</span>
-                    <span class="stat-label">Typical ROI Timeline</span>
-                </div>
+                <% }); %>
             </div>
         </div>
     </section>
@@ -616,7 +607,7 @@
             <div class="content-section" style="text-align: center;">
                 <h2>Trusted by Leading Organizations</h2>
                 <div class="trust-signal">
-                    <p><strong>Join 200+ companies</strong> that have successfully transformed their treasury operations with our expert guidance. Our proven methodology has helped organizations save an average of $2M+ annually while reducing operational risk.</p>
+                    <p><strong>Join 200+ companies</strong> that have successfully transformed their treasury operations with our expert guidance. Our proven methodology consistently reduces operational risk and improves efficiency.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add homepage stats include to insight templates
- feed homepageStats into hero partials
- replace hard-coded stat grids with homepageStats
- clean out dated savings metrics in TMS guide

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_687679892e3c8331b8d23480a08db6e9