### PR TITLE
Modify portal side toggles

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -2225,3 +2225,34 @@
         padding-bottom: 80px !important;
     }
 }
+
+/* External toggle tabs */
+.treasury-portal .external-menu-toggle,
+.treasury-portal .external-shortlist-toggle {
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 40px;
+    min-height: 100px;
+    padding: 8px 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #fff;
+    background: #7216f4;
+    border: none;
+    cursor: pointer;
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+}
+.treasury-portal .external-menu-toggle {
+    left: 0;
+    border-radius: 0 8px 8px 0;
+}
+.treasury-portal .external-shortlist-toggle {
+    right: 0;
+    border-radius: 8px 0 0 8px;
+}
+

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -4,12 +4,8 @@ if (!defined("ABSPATH")) exit;
 ?>
 <div class="treasury-portal">
     <div class="container">
-        <button class="external-menu-toggle" id="externalMenuToggle">
-            <span class="icon"></span>
-        </button>
-        <button class="external-shortlist-toggle" id="externalShortlistToggle" aria-label="Open shortlist menu" title="Shortlist">
-            <span class="icon"></span>
-        </button>
+        <button class="external-menu-toggle" id="externalMenuToggle">Menu</button>
+        <button class="external-shortlist-toggle" id="externalShortlistToggle" aria-label="Open shortlist menu" title="Shortlist">Shortlist</button>
         <!-- Loading Screen -->
         <div class="loading" id="loadingScreen" style="display: none; text-align: center; padding: 40px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
             <div class="loading-logo" style="font-size: 3rem; margin-bottom: 1rem;">💼</div>


### PR DESCRIPTION
## Summary
- show text-based tabs for external side menu toggles
- add vertical orientation styling for the tabs

## Testing
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_6876c357adc4833198f9124d24f5379e