### PR TITLE
Right align Demo indicator

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -648,7 +648,7 @@
     color: #6366f1;
     font-weight: 500;
     cursor: pointer;
-    align-self: flex-start; /* prevent full width stretch */
+    align-self: flex-end; /* right justify within header */
 }
 
         .treasury-portal .tool-card:hover .video-indicator {


### PR DESCRIPTION
## Summary
- right-align the demo indicator button on Treasury Tech Portal cards
- install dev dependencies for tests

## Testing
- `npm run test:ejs`

------
https://chatgpt.com/codex/tasks/task_e_6876c61128188331a4a3516a0fd2c778