### PR TITLE
Handle missing tools.json in portal init

### DIFF
--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -126,7 +126,9 @@ document.addEventListener('DOMContentLoaded', () => {
         class TreasuryTechPortal {
             constructor() {
                 this.TREASURY_TOOLS = [];
-                this.loadTools().then(() => this.init());
+                this.loadTools()
+                    .catch(err => console.error('Failed to load tools.json', err))
+                    .then(() => this.init());
 
                 // Category information with videos
                 this.CATEGORY_INFO = {


### PR DESCRIPTION
## Summary
- guard against tools.json fetch failure in portal constructor

## Testing
- `npm run test:ejs`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876d712a9088331a8f1c073d78eef6b