### PR TITLE
Add Prettier setup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "rt-wordpress-content",
       "version": "1.0.0",
       "devDependencies": {
-        "ejs": "^3.1.10"
+        "ejs": "^3.1.10",
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/ansi-styles": {
@@ -185,6 +186,22 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "scripts": {
     "build": "node build.js",
-    "test:ejs": "node -e \"console.log('EJS installed:', require('ejs').VERSION)\""
+    "test:ejs": "node -e \"console.log('EJS installed:', require('ejs').VERSION)\"",
+    "format": "prettier --write ."
   },
   "devDependencies": {
-    "ejs": "^3.1.10"
+    "ejs": "^3.1.10",
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- add prettier configuration
- install prettier as dev dependency
- add formatting script

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68771462b8148331862ea0b22ca00cc9