### PR TITLE
Configure mise idiomatic setting

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]


### PR DESCRIPTION
## Summary
- add `.mise.toml` enabling idiomatic version files for Node

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68771ebc05288331b92ab9e640c67c2d