### PR TITLE
Add note about ad blockers in portal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ Use the **Treasury Tech Portal** plugin (`plugins/treasury-tech-portal`) to embe
 ### Shortcode
 
 Place `[treasury_portal]` on a page or post to display the portal. The shortcode automatically enqueues `treasury-portal.css` and `treasury-portal.js` so no extra asset management is required.
+
+### Troubleshooting
+
+Some browsers or ad-blocking extensions may block requests to `*.wp.com`, resulting in `ERR_BLOCKED_BY_CLIENT` messages in the developer console. These errors are harmless and the portal will continue to function normally. If the messages are distracting, whitelist the site in your browser or ad-blocker to remove them.


### PR DESCRIPTION
## Summary
- document how ad-blockers may block requests to `*.wp.com`
- clarify the resulting errors are harmless and can be removed by whitelisting

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_6877226934d083319b3b5fbe847a25ba