### PR TITLE
Improve session handling in TPA sync

### DIFF
--- a/plugins/treasury-portal-access/includes/frontend-scripts.php
+++ b/plugins/treasury-portal-access/includes/frontend-scripts.php
@@ -705,7 +705,12 @@ if (empty($form_id)) {
                     }
                 })
                 .catch(error => {
-                    console.error('TPA: Sync failed:', error);
+                    if (error && error.message && error.message.includes('403')) {
+                        console.error('TPA: Sync failed with 403 - likely expired session');
+                        this.handleSyncFailure();
+                    } else {
+                        console.error('TPA: Sync failed:', error);
+                    }
                 });
             } catch (e) {
                 console.log('TPA: Error in syncToLocal:', e);
@@ -786,6 +791,24 @@ if (empty($form_id)) {
 
         clearLocal() {
             safeLocalStorageRemove('tpa_access_token');
+        },
+
+        handleSyncFailure() {
+            console.log('TPA: Handling sync failure');
+            try {
+                this.clearLocal();
+                document.cookie = 'portal_access_token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+                this.showMessage('Your portal session has expired. Please reauthenticate.', 'error');
+                setTimeout(() => {
+                    if (this.modal) {
+                        this.openModal();
+                    } else {
+                        window.location.reload();
+                    }
+                }, 1500);
+            } catch (e) {
+                console.error('TPA: Error in handleSyncFailure:', e);
+            }
         },
 
         executeRedirect() {


### PR DESCRIPTION
## Summary
- detect 403 errors when syncing access data
- introduce `handleSyncFailure()` to clear stale credentials and notify the user

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68772254adb483319205d0fcf447528a