### PR TITLE
Update workshop info and registration links

### DIFF
--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -134,7 +134,7 @@ function add_my_custom_header_html() {
                                             <span class="rt-service-cta">Request Access →</span>
                                         </a>
 
-                                        <a href="https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration" target="_blank" class="rt-service-item">
+                                        <a href="https://us06web.zoom.us/meeting/register/4_MGIob4Qp-nx0JSnxnJ0w" target="_blank" class="rt-service-item">
                                             <div class="rt-service-header">
                                                 <div class="rt-service-icon">💡</div>
                                                 <div class="rt-service-title">Treasury Insights Workshop</div>

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -457,10 +457,10 @@ body.banner-closed {
             
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Tech Selection</span> Workshop
+                    <span class="banner-highlight">Selecting the "Right" One</span> Workshop
                 </div>
                 <div class="banner-subtitle">
-                    Tue Jul 15 | 12:00 PM ET / 9:00 AM PT | 6 Steps to Treasury Tech Without Regret
+                    Wed Jul 30 | 2:30 PM ET | 6 Steps to Treasury Tech Without Regret
                 </div>
             </div>
         </div>
@@ -549,7 +549,7 @@ function expandBanner(event) {
 function registerWorkshop(event) {
     event.stopPropagation();
     // Redirect to the actual workshop registration
-    window.open('https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration', '_blank');
+    window.open('https://us06web.zoom.us/meeting/register/4_MGIob4Qp-nx0JSnxnJ0w', '_blank');
 }
 
 

--- a/treasury-tech-selection/workshop/index.html
+++ b/treasury-tech-selection/workshop/index.html
@@ -588,7 +588,7 @@
                         <p>Tuesday, July 15 | 12:00 PM ET / 9:00 AM PT</p>
                     </div>
                     
-                    <a href="https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration" class="cta-button">🚀 END THE MISERY - JOIN NOW</a>
+                    <a href="https://us06web.zoom.us/meeting/register/4_MGIob4Qp-nx0JSnxnJ0w" class="cta-button">🚀 END THE MISERY - JOIN NOW</a>
                 </div>
             </div>
         </div>
@@ -773,7 +773,7 @@
         <div class="container">
             <div class="cta-content">
                 <div class="button-group">
-                    <a href="https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration" class="cta-button primary-cta">🎯 Join the Workshop</a>
+                    <a href="https://us06web.zoom.us/meeting/register/4_MGIob4Qp-nx0JSnxnJ0w" class="cta-button primary-cta">🎯 Join the Workshop</a>
                     <a href="#" class="cta-button secondary-cta">📅 Skip to 15-Min Meeting</a>
                 </div>
             </div>
@@ -781,7 +781,7 @@
     </section>
 
     <!-- Fixed CTA Button -->
-    <a href="https://us06web.zoom.us/meeting/register/fnF_UW-WT-SLztDpcVWU6Q#/registration" class="fixed-cta">🚀 END THE MISERY</a>
+    <a href="https://us06web.zoom.us/meeting/register/4_MGIob4Qp-nx0JSnxnJ0w" class="fixed-cta">🚀 END THE MISERY</a>
 
     <script>
         // Smooth scrolling for anchor links


### PR DESCRIPTION
## Summary
- update upcoming workshop banner title and subtitle
- set new Zoom registration URL in the main menu banner
- update Zoom link for the "Treasury Insights Workshop" item
- replace old registration URLs across the repository
- rebuild project

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68780dabeaa08331b333a1965df30eaf