### PR TITLE
Add Username Leaderboard plugin

### DIFF
--- a/plugins/username-leaderboard/README.md
+++ b/plugins/username-leaderboard/README.md
@@ -1,0 +1,11 @@
+# Username Leaderboard
+
+Provides a simple shortcode to display all registered WordPress users.
+
+## Usage
+
+1. Copy the `username-leaderboard` folder into your site's `wp-content/plugins/` directory.
+2. Activate **Username Leaderboard** from the Plugins screen.
+3. Add the shortcode `[username_leaderboard]` to any post or page.
+
+The plugin automatically lists all users ordered by registration date. No submit button is required; user data loads directly from the database.

--- a/plugins/username-leaderboard/username-leaderboard.css
+++ b/plugins/username-leaderboard/username-leaderboard.css
@@ -1,0 +1,13 @@
+.username-leaderboard {
+    width: 100%;
+    border-collapse: collapse;
+}
+.username-leaderboard th,
+.username-leaderboard td {
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+.username-leaderboard th {
+    background: #f2f2f2;
+    text-align: left;
+}

--- a/plugins/username-leaderboard/username-leaderboard.php
+++ b/plugins/username-leaderboard/username-leaderboard.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Plugin Name: Username Leaderboard
+ * Plugin URI: https://realtreasury.com
+ * Description: Display a leaderboard of all registered users.
+ * Version: 1.0.0
+ * Author: Real Treasury
+ * License: GPL v2 or later
+ * Text Domain: username-leaderboard
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function ulb_enqueue_styles() {
+    $css_file = plugin_dir_path(__FILE__) . 'username-leaderboard.css';
+    $version  = file_exists($css_file) ? filemtime($css_file) : '1.0.0';
+    wp_enqueue_style('username-leaderboard', plugin_dir_url(__FILE__) . 'username-leaderboard.css', array(), $version);
+}
+
+function ulb_get_users_table() {
+    $users = get_users(array(
+        'orderby' => 'registered',
+        'order'   => 'DESC',
+        'fields'  => array('user_login', 'user_registered'),
+    ));
+
+    if (empty($users)) {
+        return '<p>No users found.</p>';
+    }
+
+    $output = '<table class="username-leaderboard"><thead><tr><th>Rank</th><th>Username</th><th>Registered</th></tr></thead><tbody>';
+    $rank = 1;
+    foreach ($users as $user) {
+        $output .= '<tr>';
+        $output .= '<td>' . esc_html($rank) . '</td>';
+        $output .= '<td>' . esc_html($user->user_login) . '</td>';
+        $output .= '<td>' . esc_html(date_i18n(get_option('date_format'), strtotime($user->user_registered))) . '</td>';
+        $output .= '</tr>';
+        $rank++;
+    }
+    $output .= '</tbody></table>';
+
+    return $output;
+}
+
+function ulb_shortcode() {
+    ulb_enqueue_styles();
+    return ulb_get_users_table();
+}
+add_shortcode('username_leaderboard', 'ulb_shortcode');


### PR DESCRIPTION
## Summary
- add a simple `username-leaderboard` plugin to list all registered users
- include basic styles and usage notes

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68782fe0e9048331a66cebf74cd64e8a