### PR TITLE
Fix permanent tool picker setup

### DIFF
--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -464,6 +464,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.previousFocusedElement = null;
                 this.videoTimes = {};
                 this.currentToolId = null;
+                this.permanentToolPickerInitialized = false;
                 this.spaceHandler = null;
                 this.handleOutsideSideMenuClick = (e) => {
                     const sideMenu = document.getElementById('sideMenu');
@@ -1762,12 +1763,11 @@ document.addEventListener('DOMContentLoaded', () => {
                } else {
                    portalRoot.style.overflow = 'hidden';
                }
-               const wasOpen = this.shortlistMenuOpen;
                this.shortlistMenuOpen = true;
-               if (!wasOpen) {
-                   this.setupPermanentToolPicker();
+               if (this.permanentToolPickerInitialized) {
+                   this.updatePermanentToolPicker();
                }
-            }
+           }
 
             closeShortlistMenu() {
                 const menu = document.getElementById('shortlistMenu');
@@ -1952,6 +1952,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 // Initial update
                 this.updatePermanentToolPicker();
+                this.permanentToolPickerInitialized = true;
             }
 
             clearShortlist() {


### PR DESCRIPTION
## Summary
- update shortlist menu reopen logic so permanent tool picker only sets up once
- refresh tool picker on each menu open

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_687927e618d0833183106b93a679783e