### PR TITLE
Move categories above market chart

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -629,23 +629,6 @@
             </div>
         </div>
     </section>
-
-
-
-    <section class="market-section">
-        <div class="container">
-            <div class="market-content">
-                <div class="market-text">
-                    <h2>The Treasury Tech Landscape</h2>
-                    <p>The treasury technology market has exploded with innovation, creating hundreds of solutions across different categories and price points. Understanding which category fits your needs is the first step to making the right investment.</p>
-                </div>
-                <div class="market-image">
-                    <img src="https://realtreasury.com/wp-content/uploads/2025/07/treasury-tech-market-07-2025-clean.png" alt="Treasury Tech Market Map" loading="lazy">
-                </div>
-            </div>
-        </div>
-    </section>
-
     <section class="categories-section">
         <div class="container">
             <div class="section-header">
@@ -760,6 +743,19 @@
                             <li style="--item-index: 8">Risk Management</li>
                         </ul>
                     </div>
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="market-section">
+        <div class="container">
+            <div class="market-content">
+                <div class="market-text">
+                    <h2>The Treasury Tech Landscape</h2>
+                    <p>The treasury technology market has exploded with innovation, creating hundreds of solutions across different categories and price points. Understanding which category fits your needs is the first step to making the right investment.</p>
+                </div>
+                <div class="market-image">
+                    <img src="https://realtreasury.com/wp-content/uploads/2025/07/treasury-tech-market-07-2025-clean.png" alt="Treasury Tech Market Map" loading="lazy">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- reorder Treasury Tech Market so that the Three Categories section comes before the market chart

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_6888d7ca443083318a9d0237fe50a725