### PR TITLE
Fix carousel resume after drag

### DIFF
--- a/widgets/treasury-logo-carousel/index.html
+++ b/widgets/treasury-logo-carousel/index.html
@@ -283,12 +283,19 @@
             let isDown = false;
             let startX;
             let currentX = 0;
+            function getTranslateX() {
+                const transform = getComputedStyle(track).transform;
+                if (!transform || transform === 'none') return 0;
+                const matrix = new DOMMatrix(transform);
+                return matrix.m41;
+            }
             let hasMoved = false;
 
             container.addEventListener('mousedown', (e) => {
                 isDown = true;
                 hasMoved = false;
                 track.classList.add('dragging');
+                currentX = getTranslateX();
                 startX = e.pageX;
                 container.style.cursor = 'grabbing';
                 e.preventDefault();
@@ -323,6 +330,7 @@
                 isDown = true;
                 hasMoved = false;
                 track.classList.add('dragging');
+                currentX = getTranslateX();
                 startX = e.touches[0].pageX;
             }, { passive: true });
 
@@ -351,6 +359,7 @@
 
             function resumeAnimation() {
                 if (track.classList.contains('dragging')) return;
+                currentX = getTranslateX();
                 const styles = getComputedStyle(track);
                 const duration = parseFloat(styles.animationDuration) || 40;
                 const distance = parseFloat(styles.getPropertyValue('--scroll-width')) || 0;


### PR DESCRIPTION
## Summary
- prevent jump when dragging the logo carousel by reading current transform
- restart animation from the correct position on release

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_6888f6a3bdbc8331bb28c5dc274a2455