### PR TITLE
Fix carousel width after images load

### DIFF
--- a/widgets/treasury-logo-carousel/index.html
+++ b/widgets/treasury-logo-carousel/index.html
@@ -259,13 +259,31 @@
             carouselTrack.style.setProperty('--scroll-width', trackWidth + 'px');
         }
 
+        function onImagesLoaded(track, callback) {
+            const imgs = track.querySelectorAll('img');
+            let remaining = imgs.length;
+            if (remaining === 0) {
+                callback();
+                return;
+            }
+            function done() {
+                if (--remaining === 0) {
+                    callback();
+                }
+            }
+            imgs.forEach(img => {
+                if (img.complete) {
+                    done();
+                } else {
+                    img.addEventListener('load', done, { once: true });
+                    img.addEventListener('error', done, { once: true });
+                }
+            });
+        }
+
         document.addEventListener('DOMContentLoaded', function() {
             initializeCarousel();
-            if (document.readyState === 'complete') {
-                setScrollWidth();
-            } else {
-                window.addEventListener('load', setScrollWidth);
-            }
+            onImagesLoaded(carouselTrack, setScrollWidth);
         });
 
     </script>


### PR DESCRIPTION
## Summary
- add helper `onImagesLoaded` in the logo carousel widget
- call `onImagesLoaded` instead of relying on window load
- regenerate compiled pages

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_6888fb8a49dc83319b8e2d2d9cb89790