### PR TITLE
Add video preview placeholder to tech portal header

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -203,24 +203,41 @@
             align-items: center;
             gap: 20px;
             flex: 1;
-            justify-content: center;
         }
 
         /* Stats Cards */
         .treasury-portal .stats-bar {
             display: flex;
-            gap: 20px;
+            gap: 10px;
             align-items: center;
+            margin-left: auto;
         }
 
         .treasury-portal .stat-card {
             background: white;
             border: 1px solid #e5e7eb;
             border-radius: 12px;
-            padding: 12px 16px;
+            padding: 8px 12px;
             text-align: center;
-            min-width: 100px;
+            min-width: 80px;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+        }
+
+        .treasury-portal .video-preview {
+            width: 160px;
+            height: 90px;
+            background: #000;
+            border-radius: 12px;
+            overflow: hidden;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #fff;
+            font-size: 0.75rem;
+        }
+
+        .treasury-portal .video-preview .video-placeholder {
+            pointer-events: none;
         }
 
         .treasury-portal .stat-number {

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -25,6 +25,10 @@ if (!defined("ABSPATH")) exit;
 
                 <div class="header-middle">
 
+                    <div class="video-preview" aria-label="Tech portal overview video placeholder">
+                        <span class="video-placeholder">Video Overview</span>
+                    </div>
+
                     <div class="stats-bar">
                         <div class="stat-card">
                             <div class="stat-number" id="totalTools">28</div>


### PR DESCRIPTION
## Summary
- Insert video overview placeholder alongside stats in treasury tech portal header.
- Rework stats layout for compact display and shift to the right.
- Style new video preview and updated stat cards.

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689ce2b1aad48331914e1f81f05bc3c8