### PR TITLE
Add video preview placeholder to tech portal header

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -151,10 +151,9 @@
             max-width: 1400px;
             margin: 0 auto;
             padding: 20px 40px;
-            display: flex;
+            display: grid;
+            grid-template-columns: auto 1fr auto;
             align-items: center;
-            justify-content: space-between;
-            flex-wrap: wrap;
             gap: 20px;
         }
 
@@ -197,30 +196,41 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
 
-        /* Header Middle Section */
-        .treasury-portal .header-middle {
-            display: flex;
-            align-items: center;
-            gap: 20px;
-            flex: 1;
-            justify-content: center;
-        }
-
         /* Stats Cards */
         .treasury-portal .stats-bar {
             display: flex;
-            gap: 20px;
+            gap: 10px;
             align-items: center;
+            justify-self: end;
         }
 
         .treasury-portal .stat-card {
             background: white;
             border: 1px solid #e5e7eb;
             border-radius: 12px;
-            padding: 12px 16px;
+            padding: 8px 12px;
             text-align: center;
-            min-width: 100px;
+            min-width: 80px;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+        }
+
+        .treasury-portal .video-preview {
+            width: 160px;
+            height: 90px;
+            background: #000;
+            border-radius: 12px;
+            overflow: hidden;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            justify-self: center;
+        }
+
+        .treasury-portal .video-preview video {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
         }
 
         .treasury-portal .stat-number {
@@ -247,6 +257,7 @@
             display: flex;
             gap: 4px;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+            grid-column: 1 / -1;
         }
 
         .treasury-portal .filter-tab {
@@ -1101,24 +1112,15 @@
         /* Hide external toggles across common mobile widths */
         @media (max-width: 1024px) {
             .treasury-portal .header-content {
-                flex-direction: column;
-                align-items: stretch;
+                grid-template-columns: 1fr;
                 gap: 15px;
                 padding: 20px 15px;
-            }
-
-            .treasury-portal .header-middle {
-                flex-direction: column;
-                gap: 15px;
-            }
-            
-            .treasury-portal .header-middle .search-container {
-                width: 100%;
             }
 
             .treasury-portal .stats-bar {
                 justify-content: space-around;
                 width: 100%;
+                justify-self: stretch;
             }
 
             .treasury-portal .filter-tabs {

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -23,17 +23,18 @@ if (!defined("ABSPATH")) exit;
                     </div>
                 </div>
 
-                <div class="header-middle">
+                <div class="video-preview">
+                    <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4" controls preload="metadata" aria-label="Tech portal overview video"></video>
+                </div>
 
-                    <div class="stats-bar">
-                        <div class="stat-card">
-                            <div class="stat-number" id="totalTools">28</div>
-                            <div class="stat-label">Tools</div>
-                        </div>
-                        <div class="stat-card">
-                            <div class="stat-number">3</div>
-                            <div class="stat-label">Categories</div>
-                        </div>
+                <div class="stats-bar">
+                    <div class="stat-card">
+                        <div class="stat-number" id="totalTools">28</div>
+                        <div class="stat-label">Tools</div>
+                    </div>
+                    <div class="stat-card">
+                        <div class="stat-number">3</div>
+                        <div class="stat-label">Categories</div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Embed tech portal intro video between header title and stats
- Refactor header layout to grid to center video preview and right-align stats
- Style video preview container and filter tabs for full-width alignment

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689ce2b1aad48331914e1f81f05bc3c8