### PR TITLE
Replace portal video placeholder with video tag

### DIFF
--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -25,8 +25,8 @@ if (!defined("ABSPATH")) exit;
 
                 <div class="header-middle">
 
-                    <div class="video-preview" aria-label="Tech portal overview video placeholder">
-                        <span class="video-placeholder">Video Overview</span>
+                    <div class="video-preview" aria-label="Tech portal overview video">
+                        <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4" controls></video>
                     </div>
 
                     <div class="stats-bar">


### PR DESCRIPTION
## Summary
- Render portal header video using an HTML5 `<video>` tag instead of placeholder span

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`
- `curl -I https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4` *(403 Forbidden - remote server blocked request)*

------
https://chatgpt.com/codex/tasks/task_e_689cf4c4f2008331b182ffad93e9279d