### PR TITLE
Center Treasury Tech Portal header video preview

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -153,7 +153,6 @@
             padding: 20px 40px;
             display: flex;
             align-items: center;
-            justify-content: space-between;
             flex-wrap: wrap;
             gap: 20px;
         }
@@ -197,14 +196,6 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
 
-        /* Header Middle Section */
-        .treasury-portal .header-middle {
-            display: flex;
-            align-items: center;
-            gap: 20px;
-            flex: 1;
-        }
-
         /* Stats Cards */
         .treasury-portal .stats-bar {
             display: flex;
@@ -234,6 +225,7 @@
             justify-content: center;
             color: #fff;
             font-size: 0.75rem;
+            margin: 0 auto;
         }
 
         .treasury-portal .video-preview .video-placeholder {
@@ -1122,15 +1114,6 @@
                 align-items: stretch;
                 gap: 15px;
                 padding: 20px 15px;
-            }
-
-            .treasury-portal .header-middle {
-                flex-direction: column;
-                gap: 15px;
-            }
-            
-            .treasury-portal .header-middle .search-container {
-                width: 100%;
             }
 
             .treasury-portal .stats-bar {

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -23,21 +23,18 @@ if (!defined("ABSPATH")) exit;
                     </div>
                 </div>
 
-                <div class="header-middle">
+                <div class="video-preview" aria-label="Tech portal overview video placeholder">
+                    <span class="video-placeholder">Video Overview</span>
+                </div>
 
-                    <div class="video-preview" aria-label="Tech portal overview video placeholder">
-                        <span class="video-placeholder">Video Overview</span>
+                <div class="stats-bar">
+                    <div class="stat-card">
+                        <div class="stat-number" id="totalTools">28</div>
+                        <div class="stat-label">Tools</div>
                     </div>
-
-                    <div class="stats-bar">
-                        <div class="stat-card">
-                            <div class="stat-number" id="totalTools">28</div>
-                            <div class="stat-label">Tools</div>
-                        </div>
-                        <div class="stat-card">
-                            <div class="stat-number">3</div>
-                            <div class="stat-label">Categories</div>
-                        </div>
+                    <div class="stat-card">
+                        <div class="stat-number">3</div>
+                        <div class="stat-label">Categories</div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Simplify portal header markup so the video preview sits alongside the title and stats bar
- Flex layout in header for centering the preview and keeping stats right-aligned
- Remove unused header-middle styles

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cf4cbbc64833185c32337ec06a8c4