### PR TITLE
Center treasury portal video preview

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -153,8 +153,6 @@
             padding: 20px 40px;
             display: flex;
             align-items: center;
-            justify-content: space-between;
-            flex-wrap: wrap;
             gap: 20px;
         }
 
@@ -197,14 +195,6 @@
             font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
         }
 
-        /* Header Middle Section */
-        .treasury-portal .header-middle {
-            display: flex;
-            align-items: center;
-            gap: 20px;
-            flex: 1;
-        }
-
         /* Stats Cards */
         .treasury-portal .stats-bar {
             display: flex;
@@ -234,6 +224,7 @@
             justify-content: center;
             color: #fff;
             font-size: 0.75rem;
+            margin: 0 auto;
         }
 
         .treasury-portal .video-preview .video-placeholder {
@@ -1122,15 +1113,6 @@
                 align-items: stretch;
                 gap: 15px;
                 padding: 20px 15px;
-            }
-
-            .treasury-portal .header-middle {
-                flex-direction: column;
-                gap: 15px;
-            }
-            
-            .treasury-portal .header-middle .search-container {
-                width: 100%;
             }
 
             .treasury-portal .stats-bar {

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -23,21 +23,18 @@ if (!defined("ABSPATH")) exit;
                     </div>
                 </div>
 
-                <div class="header-middle">
+                <div class="video-preview" aria-label="Tech portal overview video">
+                    <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4" controls></video>
+                </div>
 
-                    <div class="video-preview" aria-label="Tech portal overview video">
-                        <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4" controls></video>
+                <div class="stats-bar">
+                    <div class="stat-card">
+                        <div class="stat-number" id="totalTools">28</div>
+                        <div class="stat-label">Tools</div>
                     </div>
-
-                    <div class="stats-bar">
-                        <div class="stat-card">
-                            <div class="stat-number" id="totalTools">28</div>
-                            <div class="stat-label">Tools</div>
-                        </div>
-                        <div class="stat-card">
-                            <div class="stat-number">3</div>
-                            <div class="stat-label">Categories</div>
-                        </div>
+                    <div class="stat-card">
+                        <div class="stat-number">3</div>
+                        <div class="stat-label">Categories</div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Reworked treasury tech portal header to remove extra wrapper so the video preview sits alongside the logo and stats bar.
- Updated portal CSS to use flex layout, center the video preview with auto margins, and keep the stats bar aligned to the right.

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cf69488348331b7910a3e23065f16