### PR TITLE
Add intro video modal to Treasury Tech Portal

### DIFF
--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -122,6 +122,36 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    const introPreview = document.querySelector('.video-preview');
+    const introModal = document.getElementById('portalIntroModal');
+    const introVideo = document.getElementById('portalIntroVideo');
+    const introClose = document.getElementById('portalIntroClose');
+
+    if (introPreview && introModal && introVideo) {
+        introPreview.addEventListener('click', () => {
+            introVideo.src = introPreview.dataset.video;
+            treasuryTechPortal.openModal(introModal);
+            introVideo.play();
+        });
+    }
+
+    if (introClose && introVideo) {
+        introClose.addEventListener('click', () => {
+            introVideo.pause();
+            treasuryTechPortal.closeModal('portalIntroModal');
+            introVideo.removeAttribute('src');
+        });
+    }
+
+    if (introModal && introVideo) {
+        introModal.addEventListener('click', (e) => {
+            if (e.target.closest('.ttp-modal-content') === null) {
+                introVideo.pause();
+                treasuryTechPortal.closeModal('portalIntroModal');
+                introVideo.removeAttribute('src');
+            }
+        });
+    }
 });
         class TreasuryTechPortal {
             constructor() {
@@ -832,6 +862,25 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 }
 
+                const introModal = document.getElementById('portalIntroModal');
+                const introClose = document.getElementById('portalIntroClose');
+                const introVideo = document.getElementById('portalIntroVideo');
+
+                if (introClose) {
+                    introClose.addEventListener('click', () => {
+                        if (introVideo) introVideo.pause();
+                        this.closeModal('portalIntroModal');
+                    });
+                }
+                if (introModal) {
+                    introModal.addEventListener('click', (e) => {
+                        if (e.target.closest('.ttp-modal-content') === null) {
+                            if (introVideo) introVideo.pause();
+                            this.closeModal('portalIntroModal');
+                        }
+                    });
+                }
+
                 // Setup swipe-to-close for tool modal
                 this.setupSwipeToClose('toolModal', 'toolModal', () => this.closeModal('toolModal'));
 
@@ -840,8 +889,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 document.addEventListener('keydown', (e) => {
                     if (e.key === 'Escape') {
+                        if (introVideo) introVideo.pause();
                         this.closeModal('toolModal');
                         this.closeModal('categoryModal');
+                        this.closeModal('portalIntroModal');
                     }
                 });
             }

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -25,9 +25,7 @@ if (!defined("ABSPATH")) exit;
 
                 <div class="header-middle">
 
-                    <div class="video-preview" aria-label="Tech portal overview video">
-                        <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4" controls></video>
-                    </div>
+                    <button class="video-preview" aria-label="Tech portal overview video" data-video="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4"></button>
 
                     <div class="stats-bar">
                         <div class="stat-card">
@@ -242,6 +240,20 @@ if (!defined("ABSPATH")) exit;
                 </div>
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->
+                </div>
+            </div>
+        </div>
+
+        <!-- Intro Video Modal -->
+        <div class="ttp-modal" id="portalIntroModal" role="dialog" aria-modal="true">
+            <div class="ttp-modal-content" tabindex="-1">
+                <div class="modal-header">
+                    <div class="modal-header-actions">
+                        <button class="modal-close" id="portalIntroClose">×</button>
+                    </div>
+                </div>
+                <div class="modal-body">
+                    <video id="portalIntroVideo" controls autoplay></video>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- replace inline intro video with button and dedicated modal
- wire up JS to open, inject, and control intro video playback

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cf6e0d8d88331aaead17e5f9e717c