### PR TITLE
Fix video container aspect ratio in Treasury Tech Portal

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -948,11 +948,12 @@
             gap: 6px; /* Reduced gap */
         }
 
-        /* Video container - more compact */
+        /* Video container - maintain 16:9 aspect ratio */
         .treasury-portal .video-container {
             width: 100%;
             height: 0;
-            padding-bottom: 50%; /* Reduced from 56.25% */
+            padding-bottom: 56.25%; /* 16:9 aspect ratio */
+            aspect-ratio: 16 / 9;
             position: relative;
             border-radius: 8px; /* Reduced from 12px */
             overflow: hidden;


### PR DESCRIPTION
## Summary
- ensure `.video-container` maintains a 16:9 aspect ratio using `padding-bottom: 56.25%`
- add `aspect-ratio` for modern browser support

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cf6e4816483318ead6cc5071085a7