### PR TITLE
Add modal video playback for portal intro

### DIFF
--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -808,6 +808,51 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             setupModals() {
+                const introPreview = document.querySelector('.video-preview');
+                const introModal = document.getElementById('portalIntroModal');
+                const introModalClose = document.getElementById('portalIntroModalClose');
+
+                if (introPreview && introModal) {
+                    introPreview.addEventListener('click', () => {
+                        const body = introModal.querySelector('.modal-body');
+                        if (body) {
+                            body.innerHTML = '';
+                            const video = document.createElement('video');
+                            video.src = 'https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4';
+                            video.controls = true;
+                            video.autoplay = true;
+                            video.playsInline = true;
+                            body.appendChild(video);
+                            this.openModal(introModal);
+                            video.play();
+                        }
+                    });
+                }
+
+                if (introModalClose && introModal) {
+                    introModalClose.addEventListener('click', () => {
+                        const video = introModal.querySelector('video');
+                        if (video) {
+                            video.pause();
+                            video.remove();
+                        }
+                        this.closeModal('portalIntroModal');
+                    });
+                }
+
+                if (introModal) {
+                    introModal.addEventListener('click', (e) => {
+                        if (e.target.closest('.ttp-modal-content') === null) {
+                            const video = introModal.querySelector('video');
+                            if (video) {
+                                video.pause();
+                                video.remove();
+                            }
+                            this.closeModal('portalIntroModal');
+                        }
+                    });
+                }
+
                 const toolModal = document.getElementById('toolModal');
                 const toolModalClose = document.getElementById('modalClose');
 

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -23,9 +23,9 @@ if (!defined("ABSPATH")) exit;
                     </div>
                 </div>
 
-                <div class="video-preview" aria-label="Tech portal overview video">
-                    <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4" controls></video>
-                </div>
+                <button class="video-preview" id="portalIntroPreview" aria-label="Tech portal overview video">
+                    Watch Overview
+                </button>
 
                 <div class="stats-bar">
                     <div class="stat-card">
@@ -239,6 +239,18 @@ if (!defined("ABSPATH")) exit;
                 </div>
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->
+                </div>
+            </div>
+        </div>
+
+        <!-- Portal Intro Video Modal -->
+        <div class="ttp-modal" id="portalIntroModal" role="dialog" aria-modal="true" aria-label="Portal introduction video">
+            <div class="ttp-modal-content" tabindex="-1">
+                <div class="modal-header">
+                    <button class="modal-close" id="portalIntroModalClose">×</button>
+                </div>
+                <div class="modal-body">
+                    <video id="portalIntroVideo" controls autoplay></video>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace inline video with preview button and add intro video modal
- Inject intro video into modal on click and play automatically
- Pause and remove intro video when modal closes

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cf8cccc40833197733c1196021c11