### PR TITLE
Add modal playback for treasury portal intro video

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -226,12 +226,8 @@
             font-size: 0.75rem;
             margin: 0 auto;
             cursor: pointer;
-        }
-
-        .treasury-portal .video-preview video {
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
+            border: none;
+            padding: 0;
         }
 
         .treasury-portal .video-preview .video-placeholder {

--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -832,6 +832,37 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 }
 
+                const introPreview = document.querySelector('.video-preview');
+                const introModal = document.getElementById('portalIntroModal');
+                const introContainer = document.getElementById('portalIntroContainer');
+                const introClose = document.getElementById('portalIntroClose');
+
+                const closeIntro = () => {
+                    const vid = introModal?.querySelector('video');
+                    if (vid) vid.pause();
+                    if (introContainer) introContainer.innerHTML = '';
+                    this.closeModal('portalIntroModal');
+                };
+
+                if (introPreview && introModal && introContainer) {
+                    introPreview.addEventListener('click', () => {
+                        const src = introPreview.dataset.videoSrc;
+                        if (src) {
+                            introContainer.innerHTML = `<video src="${src}" controls autoplay></video>`;
+                            const vid = introContainer.querySelector('video');
+                            if (vid) vid.play();
+                        }
+                        this.openModal(introModal);
+                    });
+                }
+
+                if (introClose) introClose.addEventListener('click', closeIntro);
+                if (introModal) {
+                    introModal.addEventListener('click', (e) => {
+                        if (e.target.closest('.ttp-modal-content') === null) closeIntro();
+                    });
+                }
+
                 // Setup swipe-to-close for tool modal
                 this.setupSwipeToClose('toolModal', 'toolModal', () => this.closeModal('toolModal'));
 
@@ -842,6 +873,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (e.key === 'Escape') {
                         this.closeModal('toolModal');
                         this.closeModal('categoryModal');
+                        closeIntro();
                     }
                 });
             }

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -23,9 +23,9 @@ if (!defined("ABSPATH")) exit;
                     </div>
                 </div>
 
-                <div class="video-preview" aria-label="Tech portal overview video">
-                    <video src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4"></video>
-                </div>
+                <button class="video-preview" type="button" aria-label="Tech portal overview video" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4">
+                    <span class="video-placeholder">▶</span>
+                </button>
 
                 <div class="stats-bar">
                     <div class="stat-card">
@@ -240,12 +240,25 @@ if (!defined("ABSPATH")) exit;
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->
                 </div>
-            </div>
         </div>
+    </div>
 
-        <!-- Tool Details Modal -->
-        <div class="ttp-modal" id="toolModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
-            <div class="ttp-modal-content" tabindex="-1">
+    <!-- Intro Video Modal -->
+    <div class="ttp-modal" id="portalIntroModal" role="dialog" aria-modal="true">
+        <div class="ttp-modal-content" tabindex="-1">
+            <div class="modal-header">
+                <div></div>
+                <div class="modal-header-actions">
+                    <button class="modal-close" id="portalIntroClose">×</button>
+                </div>
+            </div>
+            <div class="modal-body" id="portalIntroContainer"></div>
+        </div>
+    </div>
+
+    <!-- Tool Details Modal -->
+    <div class="ttp-modal" id="toolModal" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+        <div class="ttp-modal-content" tabindex="-1">
                 <div class="modal-header">
                     <div class="modal-title-group">
                         <h3 class="modal-title" id="modalTitle"></h3>


### PR DESCRIPTION
## Summary
- Replace inline intro video with button trigger and inject modal markup for playback
- Add JavaScript handlers to load video into modal, open/close it, and manage playback
- Style video preview button for consistent appearance

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cfa6ba0808331ab46dfcd72c11019