### PR TITLE
Maintain Treasury Tech Portal header layout on tablets

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -224,7 +224,6 @@
             justify-content: center;
             color: #fff;
             font-size: 0.75rem;
-            margin: 0 auto;
             cursor: pointer;
         }
 
@@ -1116,18 +1115,6 @@
         /* Mobile adjustments */
         /* Hide external toggles across common mobile widths */
         @media (max-width: 1024px) {
-            .treasury-portal .header-content {
-                flex-direction: column;
-                align-items: stretch;
-                gap: 15px;
-                padding: 20px 15px;
-            }
-
-            .treasury-portal .stats-bar {
-                justify-content: space-around;
-                width: 100%;
-            }
-
             .treasury-portal .filter-tabs {
                 flex-wrap: wrap;
                 justify-content: center;
@@ -1279,14 +1266,32 @@
                 z-index: 1;
             }
 
-            .treasury-portal .ttp-modal.show .ttp-modal-content::before {
-                background: rgba(114, 22, 244, 0.6);
-            }
-
+        .treasury-portal .ttp-modal.show .ttp-modal-content::before {
+            background: rgba(114, 22, 244, 0.6);
         }
 
-        /* Side Menu Toggle Button */
-        .treasury-portal .menu-toggle {
+    }
+
+    @media (max-width: 768px) {
+        .treasury-portal .header-content {
+            flex-direction: column;
+            align-items: stretch;
+            gap: 15px;
+            padding: 20px 15px;
+        }
+
+        .treasury-portal .stats-bar {
+            justify-content: space-around;
+            width: 100%;
+        }
+
+        .treasury-portal .video-preview {
+            margin: 0 auto;
+        }
+    }
+
+    /* Side Menu Toggle Button */
+    .treasury-portal .menu-toggle {
             background: rgba(255,255,255,0.25);
             border: 1px solid rgba(255,255,255,0.3);
             backdrop-filter: blur(8px);


### PR DESCRIPTION
## Summary
- Keep Treasury Tech Portal header content in row layout until 768px to avoid early stacking on tablet screens.
- Center video preview and adjust stats bar only on small screens while removing default auto-centering to keep items side-by-side on larger screens.

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689cfaecddf08331b0f941aa153c16db