### PR TITLE
Use external intro video URL

### DIFF
--- a/mu-plugins/ttp-intro-video.php
+++ b/mu-plugins/ttp-intro-video.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Define the intro video URL for the Treasury Tech Portal.
+ */
+if (!defined('TTP_INTRO_VIDEO_URL')) {
+    define('TTP_INTRO_VIDEO_URL', 'https://realtreasury.com/wp-content/uploads/2024/06/Portal-Intro.mp4');
+}
+

--- a/plugins/treasury-tech-portal/assets/js/treasury-portal.js
+++ b/plugins/treasury-tech-portal/assets/js/treasury-portal.js
@@ -832,35 +832,27 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                 }
 
-                const introPreview = document.querySelector('.video-preview');
-                const introModal = document.getElementById('portalIntroModal');
-                const introContainer = document.getElementById('portalIntroContainer');
-                const introClose = document.getElementById('portalIntroClose');
+                const container = document.querySelector('.treasury-portal');
+                const src = container?.getAttribute('data-video-src') || '';
 
-                const closeIntro = () => {
-                    const vid = introModal?.querySelector('video');
-                    if (vid) vid.pause();
-                    if (introContainer) introContainer.innerHTML = '';
-                    this.closeModal('portalIntroModal');
-                };
+                if (src) {
+                    const video = document.createElement('video');
+                    video.src = src;
+                    video.controls = true;
+                    video.autoplay = true;
+                    video.muted = true;
+                    video.playsInline = true;
+                    video.preload = 'metadata';
 
-                if (introPreview && introModal && introContainer) {
-                    introPreview.addEventListener('click', () => {
-                        const src = introPreview.dataset.videoSrc;
-                        if (src) {
-                            introContainer.innerHTML = `<video src="${src}" controls autoplay></video>`;
-                            const vid = introContainer.querySelector('video');
-                            if (vid) vid.play();
-                        }
-                        this.openModal(introModal);
-                    });
-                }
+                    video.onerror = () => {
+                        container.innerHTML = '<div class="intro-video-fallback">Intro video unavailable</div>';
+                    };
 
-                if (introClose) introClose.addEventListener('click', closeIntro);
-                if (introModal) {
-                    introModal.addEventListener('click', (e) => {
-                        if (e.target.closest('.ttp-modal-content') === null) closeIntro();
-                    });
+                    const target = container.querySelector('.intro-video-target') || container;
+                    target.innerHTML = '';
+                    target.appendChild(video);
+                } else {
+                    container.innerHTML = '<div class="intro-video-fallback">Intro video unavailable</div>';
                 }
 
                 // Setup swipe-to-close for tool modal
@@ -873,7 +865,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (e.key === 'Escape') {
                         this.closeModal('toolModal');
                         this.closeModal('categoryModal');
-                        closeIntro();
                     }
                 });
             }

--- a/plugins/treasury-tech-portal/includes/shortcode.php
+++ b/plugins/treasury-tech-portal/includes/shortcode.php
@@ -1,8 +1,16 @@
 <?php
 // Exit if accessed directly
 if (!defined("ABSPATH")) exit;
+
+$video_url = defined('TTP_INTRO_VIDEO_URL')
+    ? TTP_INTRO_VIDEO_URL
+    : get_option('ttp_intro_video_url', '');
+
+if ($video_url && !wp_http_validate_url($video_url)) {
+    $video_url = '';
+}
 ?>
-<div class="treasury-portal">
+<div class="treasury-portal" data-video-src="<?php echo esc_url($video_url); ?>">
     <div class="container">
         <button class="external-menu-toggle" id="externalMenuToggle">Menu</button>
         <button class="external-shortlist-toggle" id="externalShortlistToggle" aria-label="Open shortlist menu" title="Shortlist">Shortlist</button>
@@ -23,9 +31,7 @@ if (!defined("ABSPATH")) exit;
                     </div>
                 </div>
 
-                <button class="video-preview" type="button" aria-label="Tech portal overview video" data-video-src="https://realtreasury.com/wp-content/uploads/2025/08/Portal-Intro.mp4">
-                    <span class="video-placeholder">▶</span>
-                </button>
+                <div class="intro-video-target"></div>
 
                 <div class="stats-bar">
                     <div class="stat-card">
@@ -240,19 +246,6 @@ if (!defined("ABSPATH")) exit;
                 <div class="tools-grid" id="tools-TRMS">
                     <!-- Tools will be populated by JavaScript -->
                 </div>
-        </div>
-    </div>
-
-    <!-- Intro Video Modal -->
-    <div class="ttp-modal" id="portalIntroModal" role="dialog" aria-modal="true">
-        <div class="ttp-modal-content" tabindex="-1">
-            <div class="modal-header">
-                <div></div>
-                <div class="modal-header-actions">
-                    <button class="modal-close" id="portalIntroClose">×</button>
-                </div>
-            </div>
-            <div class="modal-body" id="portalIntroContainer"></div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- define intro video URL constant via mu-plugin
- expose the URL through the treasury portal shortcode with a data attribute and placeholder
- load intro video from the data attribute in JavaScript with an unavailable fallback

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689d09a303708331b2a0278393821f1e