### PR TITLE
Limit intro video size

### DIFF
--- a/plugins/treasury-tech-portal/assets/css/treasury-portal.css
+++ b/plugins/treasury-tech-portal/assets/css/treasury-portal.css
@@ -233,6 +233,14 @@
             pointer-events: none;
         }
 
+        .treasury-portal .intro-video-target video {
+            width: 160px;
+            height: 90px;
+            border-radius: 12px;
+            display: block;
+            object-fit: cover;
+        }
+
         .treasury-portal .stat-number {
             font-size: 1.4rem;
             font-weight: 700;


### PR DESCRIPTION
## Summary
- constrain intro video within Treasury Tech Portal header to 160x90 and cover object fit

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_689df97658a48331bb7cda3f067a87e4