### PR TITLE
Add chart title overlay to treasury tech market page

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -19,6 +19,8 @@
             --text-light: #525252;
             --bg: #ffffff;
             --success: #10b981;
+            --light-purple: #c77dff;
+            --dark-text: #281345;
         }
 
         body {
@@ -114,9 +116,10 @@
         }
 
         .market-image {
+            position: relative;
             border-radius: 16px;
             overflow: hidden;
-            box-shadow: 
+            box-shadow:
                 0 16px 32px rgba(0, 0, 0, 0.1),
                 0 0 0 1px rgba(0, 0, 0, 0.05);
         }
@@ -125,6 +128,46 @@
             width: 100%;
             height: auto;
             display: block;
+        }
+
+        /* Chart Title Overlay */
+        .chart-title-overlay {
+            position: absolute;
+            top: -20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(255, 255, 255, 0.03);
+            backdrop-filter: blur(12px);
+            -webkit-backdrop-filter: blur(12px);
+            color: var(--dark-text);
+            padding: 12px 20px;
+            border-radius: 16px;
+            z-index: 3;
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+            width: auto;
+            min-width: 320px;
+            max-width: 90%;
+            text-align: center;
+            line-height: 1.3;
+            transition: all 0.3s ease;
+        }
+
+        .chart-title-overlay h3 {
+            color: var(--dark-text);
+            font-size: 1rem;
+            margin: 0 0 4px 0;
+            font-weight: 700;
+            text-shadow: 0 2px 6px rgba(0,0,0,0.5);
+            white-space: nowrap;
+        }
+
+        .chart-title-overlay p {
+            color: var(--light-purple);
+            font-size: 1.1rem;
+            margin: 0;
+            opacity: 0.95;
+            text-shadow: 0 1px 4px rgba(0,0,0,0.5);
         }
 
         /* Categories */
@@ -601,8 +644,20 @@
             .category-card {
                 padding: 28px;
             }
+            .chart-title-overlay {
+                padding: 8px 14px;
+                top: -20px;
+                line-height: 1.3;
+            }
 
+            .chart-title-overlay h3 {
+                font-size: 0.85rem;
+                white-space: nowrap;
+            }
 
+            .chart-title-overlay p {
+                font-size: 0.85rem;
+            }
 
             .cta-content h2 {
                 font-size: 32px;
@@ -755,6 +810,10 @@
                     <p>The treasury technology market has exploded with innovation, creating hundreds of solutions across different categories and price points. Understanding which category fits your needs is the first step to making the right investment.</p>
                 </div>
                 <div class="market-image">
+                    <div class="chart-title-overlay">
+                        <h3>Treasury &amp; Risk Management Systems</h3>
+                        <p>North American Vendors</p>
+                    </div>
                     <img src="https://realtreasury.com/wp-content/uploads/2025/08/treasury-tech-market-08-2025-clean.webp" alt="Treasury Tech Market Map" loading="lazy">
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add dark/light accent CSS variables and chart overlay styles
- Display chart title overlay above market map with mobile responsiveness

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68a47d6a05448331a8dd0a12e6323aff