### PR TITLE
Enlarge chart title overlay and adjust mobile styles

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -283,13 +283,13 @@
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
             color: var(--dark-text);
-            padding: 12px 20px;
+            padding: 16px 28px; /* Increased from 12px 20px */
             border-radius: 16px;
             z-index: 10;
             border: 1px solid rgba(255, 255, 255, 0.15);
             box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
             width: auto;
-            min-width: 320px;
+            min-width: 400px; /* Increased from 320px */
             max-width: 90%;
             text-align: center;
             line-height: 1.3;
@@ -298,8 +298,8 @@
 
         .chart-title-overlay h3 {
             color: var(--dark-text);
-            font-size: 1rem;
-            margin: 0 0 4px 0;
+            font-size: 1.2rem; /* Increased from 1rem */
+            margin: 0 0 6px 0; /* Increased margin from 4px */
             font-weight: 700;
             text-shadow: 0 2px 6px rgba(0,0,0,0.5);
             white-space: nowrap;
@@ -307,7 +307,7 @@
 
         .chart-title-overlay p {
             color: var(--light-purple);
-            font-size: 1.1rem;
+            font-size: 1.3rem; /* Increased from 1.1rem */
             margin: 0;
             opacity: 0.95;
             text-shadow: 0 1px 4px rgba(0,0,0,0.5);
@@ -978,18 +978,19 @@
             }
             
             .chart-title-overlay {
-                padding: 8px 14px;
+                padding: 12px 20px; /* Increased from 8px 14px */
                 top: -20px;
                 line-height: 1.3;
+                min-width: 320px; /* Keep reasonable on mobile */
             }
 
             .chart-title-overlay h3 {
-                font-size: 0.85rem;
+                font-size: 1rem; /* Increased from 0.85rem */
                 white-space: nowrap;
             }
 
             .chart-title-overlay p {
-                font-size: 0.85rem;
+                font-size: 1.1rem; /* Increased from 0.85rem */
             }
         }
 

--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -89,7 +89,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    padding: 12px 20px;
+    padding: 16px 28px; /* Increased from 12px 20px */
     background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(248,248,248,0.98));
     backdrop-filter: blur(20px) saturate(130%);
     -webkit-backdrop-filter: blur(20px) saturate(130%);
@@ -2344,13 +2344,13 @@ body.banner-closed {
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     color: var(--dark-text);
-    padding: 12px 20px;
+    padding: 16px 28px; /* Increased from 12px 20px */
     border-radius: 16px;
     z-index: 10;
     border: 1px solid rgba(255, 255, 255, 0.15);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
     width: auto;
-    min-width: 320px;
+    min-width: 400px; /* Increased from 320px */
     max-width: 90%;
     text-align: center;
     line-height: 1.3;
@@ -2359,8 +2359,8 @@ body.banner-closed {
 
 .chart-title-overlay h3 {
     color: var(--dark-text);
-    font-size: 1rem;
-    margin: 0 0 4px 0;
+    font-size: 1.2rem; /* Increased from 1rem */
+    margin: 0 0 6px 0; /* Increased margin from 4px */
     font-weight: 700;
     text-shadow: 0 2px 6px rgba(0,0,0,0.5);
     white-space: nowrap;
@@ -2368,7 +2368,7 @@ body.banner-closed {
 
 .chart-title-overlay p {
     color: var(--light-purple);
-    font-size: 1.1rem;
+    font-size: 1.3rem; /* Increased from 1.1rem */
     margin: 0;
     opacity: 0.95;
     text-shadow: 0 1px 4px rgba(0,0,0,0.5);
@@ -2376,16 +2376,17 @@ body.banner-closed {
 
 @media (max-width: 768px) {
     .chart-title-overlay {
-        padding: 8px 14px;
+        padding: 12px 20px; /* Increased from 8px 14px */
         top: -20px;
         line-height: 1.3;
+        min-width: 320px; /* Keep reasonable on mobile */
     }
     .chart-title-overlay h3 {
-        font-size: 0.85rem;
+        font-size: 1rem; /* Increased from 0.85rem */
         white-space: nowrap;
     }
     .chart-title-overlay p {
-        font-size: 0.85rem;
+        font-size: 1.1rem; /* Increased from 0.85rem */
     }
 }
 

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -143,13 +143,13 @@
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
             color: var(--dark-text);
-            padding: 12px 20px;
+            padding: 16px 28px; /* Increased from 12px 20px */
             border-radius: 16px;
             z-index: 10;
             border: 1px solid rgba(255, 255, 255, 0.15);
             box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
             width: auto;
-            min-width: 320px;
+            min-width: 400px; /* Increased from 320px */
             max-width: 90%;
             text-align: center;
             line-height: 1.3;
@@ -158,8 +158,8 @@
 
         .chart-title-overlay h3 {
             color: var(--dark-text);
-            font-size: 1rem;
-            margin: 0 0 4px 0;
+            font-size: 1.2rem; /* Increased from 1rem */
+            margin: 0 0 6px 0; /* Increased margin from 4px */
             font-weight: 700;
             text-shadow: 0 2px 6px rgba(0,0,0,0.5);
             white-space: nowrap;
@@ -167,7 +167,7 @@
 
         .chart-title-overlay p {
             color: var(--light-purple);
-            font-size: 1.1rem;
+            font-size: 1.3rem; /* Increased from 1.1rem */
             margin: 0;
             opacity: 0.95;
             text-shadow: 0 1px 4px rgba(0,0,0,0.5);
@@ -648,18 +648,19 @@
                 padding: 28px;
             }
             .chart-title-overlay {
-                padding: 8px 14px;
+                padding: 12px 20px; /* Increased from 8px 14px */
                 top: -20px;
                 line-height: 1.3;
+                min-width: 320px; /* Keep reasonable on mobile */
             }
 
             .chart-title-overlay h3 {
-                font-size: 0.85rem;
+                font-size: 1rem; /* Increased from 0.85rem */
                 white-space: nowrap;
             }
 
             .chart-title-overlay p {
-                font-size: 0.85rem;
+                font-size: 1.1rem; /* Increased from 0.85rem */
             }
 
             .cta-content h2 {


### PR DESCRIPTION
## Summary
- increase chart title overlay padding and width
- bump overlay heading and paragraph font sizes
- update mobile overlay sizing and font scaling

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68a48954ce908331be53651a4f89348b