### PR TITLE
feat: add large chart overlay for treasury tech page

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -283,13 +283,13 @@
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
             color: var(--dark-text);
-            padding: 16px 28px; /* Increased from 12px 20px */
+            padding: 12px 20px; /* Original size */
             border-radius: 16px;
-            z-index: 10;
+            z-index: 3;
             border: 1px solid rgba(255, 255, 255, 0.15);
             box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
             width: auto;
-            min-width: 400px; /* Increased from 320px */
+            min-width: 320px; /* Original size */
             max-width: 90%;
             text-align: center;
             line-height: 1.3;
@@ -298,8 +298,8 @@
 
         .chart-title-overlay h3 {
             color: var(--dark-text);
-            font-size: 1.2rem; /* Increased from 1rem */
-            margin: 0 0 6px 0; /* Increased margin from 4px */
+            font-size: 1rem; /* Original size */
+            margin: 0 0 4px 0; /* Original spacing */
             font-weight: 700;
             text-shadow: 0 2px 6px rgba(0,0,0,0.5);
             white-space: nowrap;
@@ -307,7 +307,7 @@
 
         .chart-title-overlay p {
             color: var(--light-purple);
-            font-size: 1.3rem; /* Increased from 1.1rem */
+            font-size: 1.1rem; /* Original size */
             margin: 0;
             opacity: 0.95;
             text-shadow: 0 1px 4px rgba(0,0,0,0.5);
@@ -978,19 +978,19 @@
             }
             
             .chart-title-overlay {
-                padding: 12px 20px; /* Increased from 8px 14px */
+                padding: 8px 14px;
                 top: -20px;
                 line-height: 1.3;
-                min-width: 320px; /* Keep reasonable on mobile */
+                min-width: 260px;
             }
 
             .chart-title-overlay h3 {
-                font-size: 1rem; /* Increased from 0.85rem */
+                font-size: 0.85rem;
                 white-space: nowrap;
             }
 
             .chart-title-overlay p {
-                font-size: 1.1rem; /* Increased from 0.85rem */
+                font-size: 0.85rem;
             }
         }
 

--- a/assets/css/shared.css
+++ b/assets/css/shared.css
@@ -2344,13 +2344,13 @@ body.banner-closed {
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     color: var(--dark-text);
-    padding: 16px 28px; /* Increased from 12px 20px */
+    padding: 12px 20px; /* Original size */
     border-radius: 16px;
-    z-index: 10;
+    z-index: 3;
     border: 1px solid rgba(255, 255, 255, 0.15);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
     width: auto;
-    min-width: 400px; /* Increased from 320px */
+    min-width: 320px; /* Original size */
     max-width: 90%;
     text-align: center;
     line-height: 1.3;
@@ -2359,8 +2359,8 @@ body.banner-closed {
 
 .chart-title-overlay h3 {
     color: var(--dark-text);
-    font-size: 1.2rem; /* Increased from 1rem */
-    margin: 0 0 6px 0; /* Increased margin from 4px */
+    font-size: 1rem; /* Original size */
+    margin: 0 0 4px 0; /* Original spacing */
     font-weight: 700;
     text-shadow: 0 2px 6px rgba(0,0,0,0.5);
     white-space: nowrap;
@@ -2368,7 +2368,47 @@ body.banner-closed {
 
 .chart-title-overlay p {
     color: var(--light-purple);
-    font-size: 1.3rem; /* Increased from 1.1rem */
+    font-size: 1.1rem; /* Original size */
+    margin: 0;
+    opacity: 0.95;
+    text-shadow: 0 1px 4px rgba(0,0,0,0.5);
+}
+
+/* New larger overlay for treasury tech market page */
+.chart-title-overlay-large {
+    position: absolute;
+    top: -20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255, 255, 255, 0.03);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    color: var(--dark-text);
+    padding: 16px 28px; /* Larger padding */
+    border-radius: 16px;
+    z-index: 10;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    width: auto;
+    min-width: 400px; /* Larger width */
+    max-width: 90%;
+    text-align: center;
+    line-height: 1.3;
+    transition: all 0.3s ease;
+}
+
+.chart-title-overlay-large h3 {
+    color: var(--dark-text);
+    font-size: 1.2rem; /* Larger text */
+    margin: 0 0 6px 0; /* Larger spacing */
+    font-weight: 700;
+    text-shadow: 0 2px 6px rgba(0,0,0,0.5);
+    white-space: nowrap;
+}
+
+.chart-title-overlay-large p {
+    color: var(--light-purple);
+    font-size: 1.3rem; /* Larger text */
     margin: 0;
     opacity: 0.95;
     text-shadow: 0 1px 4px rgba(0,0,0,0.5);
@@ -2376,17 +2416,35 @@ body.banner-closed {
 
 @media (max-width: 768px) {
     .chart-title-overlay {
-        padding: 12px 20px; /* Increased from 8px 14px */
+        padding: 8px 14px;
         top: -20px;
         line-height: 1.3;
-        min-width: 320px; /* Keep reasonable on mobile */
+        min-width: 260px;
     }
+
     .chart-title-overlay h3 {
-        font-size: 1rem; /* Increased from 0.85rem */
+        font-size: 0.85rem;
         white-space: nowrap;
     }
+
     .chart-title-overlay p {
-        font-size: 1.1rem; /* Increased from 0.85rem */
+        font-size: 0.85rem;
+    }
+
+    .chart-title-overlay-large {
+        padding: 12px 20px;
+        top: -20px;
+        line-height: 1.3;
+        min-width: 320px;
+    }
+
+    .chart-title-overlay-large h3 {
+        font-size: 1rem;
+        white-space: nowrap;
+    }
+
+    .chart-title-overlay-large p {
+        font-size: 1.1rem;
     }
 }
 

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -134,7 +134,7 @@
         }
 
         /* Chart Title Overlay */
-        .chart-title-overlay {
+        .chart-title-overlay-large {
             position: absolute;
             top: -20px;
             left: 50%;
@@ -143,31 +143,31 @@
             backdrop-filter: blur(12px);
             -webkit-backdrop-filter: blur(12px);
             color: var(--dark-text);
-            padding: 16px 28px; /* Increased from 12px 20px */
+            padding: 16px 28px; /* Larger padding */
             border-radius: 16px;
             z-index: 10;
             border: 1px solid rgba(255, 255, 255, 0.15);
             box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
             width: auto;
-            min-width: 400px; /* Increased from 320px */
+            min-width: 400px; /* Larger width */
             max-width: 90%;
             text-align: center;
             line-height: 1.3;
             transition: all 0.3s ease;
         }
 
-        .chart-title-overlay h3 {
+        .chart-title-overlay-large h3 {
             color: var(--dark-text);
-            font-size: 1.2rem; /* Increased from 1rem */
-            margin: 0 0 6px 0; /* Increased margin from 4px */
+            font-size: 1.2rem; /* Larger text */
+            margin: 0 0 6px 0; /* Larger spacing */
             font-weight: 700;
             text-shadow: 0 2px 6px rgba(0,0,0,0.5);
             white-space: nowrap;
         }
 
-        .chart-title-overlay p {
+        .chart-title-overlay-large p {
             color: var(--light-purple);
-            font-size: 1.3rem; /* Increased from 1.1rem */
+            font-size: 1.3rem; /* Larger text */
             margin: 0;
             opacity: 0.95;
             text-shadow: 0 1px 4px rgba(0,0,0,0.5);
@@ -647,20 +647,20 @@
             .category-card {
                 padding: 28px;
             }
-            .chart-title-overlay {
-                padding: 12px 20px; /* Increased from 8px 14px */
+            .chart-title-overlay-large {
+                padding: 12px 20px;
                 top: -20px;
                 line-height: 1.3;
-                min-width: 320px; /* Keep reasonable on mobile */
+                min-width: 320px;
             }
 
-            .chart-title-overlay h3 {
-                font-size: 1rem; /* Increased from 0.85rem */
+            .chart-title-overlay-large h3 {
+                font-size: 1rem;
                 white-space: nowrap;
             }
 
-            .chart-title-overlay p {
-                font-size: 1.1rem; /* Increased from 0.85rem */
+            .chart-title-overlay-large p {
+                font-size: 1.1rem;
             }
 
             .cta-content h2 {
@@ -814,7 +814,7 @@
                     <p>The treasury technology market has exploded with innovation, creating hundreds of solutions across different categories and price points. Understanding which category fits your needs is the first step to making the right investment.</p>
                 </div>
                 <div class="market-image">
-                    <div class="chart-title-overlay">
+                    <div class="chart-title-overlay-large">
                         <h3>Treasury &amp; Risk Management Systems</h3>
                         <p>North American Vendors</p>
                     </div>


### PR DESCRIPTION
## Summary
- restore original chart overlay sizing on the homepage
- introduce `.chart-title-overlay-large` for the Treasury Tech Market map
- apply responsive tweaks for both overlay sizes

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68a48c7f2258833195e7254577cd106e