### PR TITLE
Enable debugging and error handling for RTBCB forms

### DIFF
--- a/plugins/rtbcb/inc/class-rtbcb-router.php
+++ b/plugins/rtbcb/inc/class-rtbcb-router.php
@@ -1,0 +1,67 @@
+<?php
+
+class RTBCB_Router {
+    public function handle_form_submission() {
+        // Nonce verification
+        if (!isset($_POST['rtbcb_nonce']) || !wp_verify_nonce($_POST['rtbcb_nonce'], 'rtbcb_form_action')) {
+            wp_send_json_error(['message' => 'Nonce verification failed.'], 403);
+            return;
+        }
+
+        try {
+            // Sanitize and validate input
+            $validator = new RTBCB_Validator();
+            $validated_data = $validator->validate($_POST);
+
+            if (isset($validated_data['error'])) {
+                wp_send_json_error(['message' => $validated_data['error']], 400);
+                return;
+            }
+
+            $form_data = $validated_data;
+
+            // Instantiate necessary classes
+            $calculator = new RTBCB_Calculator();
+            $llm = new RTBCB_LLM();
+            $rag = new RTBCB_RAG();
+
+            // Perform calculations
+            $calculations = $calculator->calculate($form_data);
+
+            // Generate context from RAG
+            $rag_context = $rag->get_context($form_data['company_description']);
+
+            // Generate business case with LLM
+            $business_case_data = $llm->generate_business_case($form_data, $calculations, $rag_context);
+
+            // Save the lead
+            $leads = new RTBCB_Leads();
+            $lead_id = $leads->save_lead($form_data, $business_case_data);
+
+            // Check for LLM generation errors
+            if (is_wp_error($business_case_data)) {
+                throw new Exception($business_case_data->get_error_message());
+            }
+
+            // Generate PDF
+            $pdf = new RTBCB_PDF();
+            $pdf_path = $pdf->generate($lead_id, $business_case_data);
+
+            // Send success response
+            wp_send_json_success([
+                'message' => 'Business case generated successfully.',
+                'report_id' => $lead_id,
+                'pdf_url' => $pdf_path,
+                'report_html' => $this->get_report_html($business_case_data),
+            ]);
+
+        } catch (Exception $e) {
+            // Log the detailed error to debug.log
+            error_log('RTBCB Form Submission Error: ' . $e->getMessage());
+
+            // Send a generic error response to the client
+            wp_send_json_error(['message' => 'An unexpected error occurred while generating your report. Please check the server logs for more details. Error: ' . $e->getMessage()], 500);
+        }
+    }
+}
+

--- a/plugins/rtbcb/public/js/rtbcb.js
+++ b/plugins/rtbcb/public/js/rtbcb.js
@@ -1,0 +1,84 @@
+/**
+ * Handles the display of submission errors on the frontend.
+ * @param {string} errorMessage - The error message to display.
+ */
+function handleSubmissionError(errorMessage) {
+    console.error('Submission Error:', errorMessage);
+    const progressContainer = document.getElementById('rtbcb-progress-container');
+    if (progressContainer) {
+        progressContainer.innerHTML = `
+            <div class="rtbcb-error-content">
+                <h3 style="color: #dc3545;">Generation Failed</h3>
+                <p>We're sorry, but we couldn't generate your business case. Please try again later.</p>
+                <p style="font-size: 0.9em; color: #6c757d; margin-top: 15px;"><strong>Error Details:</strong> ${errorMessage}</p>
+            </div>
+        `;
+    }
+}
+
+/**
+ * Handles the form submission by sending data to the backend.
+ * @param {Event} e - The form submission event.
+ */
+async function handleSubmit(e) {
+    e.preventDefault();
+    const form = e.target;
+    const formData = new FormData(form);
+    const progressContainer = document.getElementById('rtbcb-progress-container');
+    const formContainer = document.getElementById('rtbcb-form-container');
+
+    // Show progress indicator
+    if (formContainer) formContainer.style.display = 'none';
+    if (progressContainer) progressContainer.style.display = 'block';
+
+    try {
+        const response = await fetch(rtbcb_ajax.ajax_url, {
+            method: 'POST',
+            body: formData,
+        });
+
+        // Check for server-side errors (like 404, 500, etc.)
+        if (!response.ok) {
+            const errorText = await response.text();
+            let errorMessage = `Server responded with status ${response.status}.`;
+            try {
+                // Try to parse as JSON for detailed error from wp_send_json_error
+                const errorJson = JSON.parse(errorText);
+                errorMessage = errorJson.data.message || errorMessage;
+            } catch (jsonError) {
+                // Fallback if the response is not JSON (e.g., HTML error page)
+                console.error("Could not parse error response as JSON.", jsonError);
+                errorMessage = errorText || errorMessage;
+            }
+            throw new Error(errorMessage);
+        }
+
+        const result = await response.json();
+
+        // Check for application-specific errors from wp_send_json_error
+        if (!result.success) {
+            throw new Error(result.data.message || 'An unknown error occurred.');
+        }
+
+        // On success, display the report
+        const reportContainer = document.getElementById('rtbcb-report-container');
+        if (progressContainer) progressContainer.style.display = 'none';
+        if (reportContainer) {
+            reportContainer.innerHTML = result.data.report_html;
+            reportContainer.style.display = 'block';
+        }
+
+    } catch (error) {
+        // Catch any network errors or thrown exceptions and display them
+        handleSubmissionError(error.message);
+    }
+}
+
+// Ensure the form submission is handled by our new function
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('rtbcb-form');
+    if (form) {
+        form.addEventListener('submit', handleSubmit);
+    }
+});
+

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,12 @@
+<?php
+
+// Enable WP_DEBUG mode
+define( 'WP_DEBUG', true );
+
+// Enable Debug logging to the /wp-content/debug.log file
+define( 'WP_DEBUG_LOG', true );
+
+// Disable display of errors and warnings
+define( 'WP_DEBUG_DISPLAY', false );
+@ini_set( 'display_errors', 0 );
+


### PR DESCRIPTION
## Summary
- Enable WordPress debugging and log errors without display
- Add try/catch-based server error handling for RTBCB form submissions
- Provide client-side submission error UI for RTBCB form

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68a7d6e2bbd08331a58f537da00a3c2f