### PR TITLE
Update workshop details for September 2025 session

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -460,7 +460,7 @@ body.banner-closed {
                     <span class="banner-highlight">TMS at AFP: But Can It Make My Coffee?</span>
                 </div>
                 <div class="banner-subtitle">
-                    Aug 27, 2025 | 3:00 PM ET.
+                    Sep 24, 2025 | 2:00 PM ET.
                 </div>
             </div>
         </div>

--- a/treasury-tech-selection/workshop/index.html
+++ b/treasury-tech-selection/workshop/index.html
@@ -567,14 +567,12 @@
                     <h1>TMS at AFP: But Can It Make My Coffee? How to Separate Buzzwords From Real Benefits in the Exhibit Hall.</h1>
                     
                     <div class="pain-points-list">
-                        <h3>If you are a treasurer, pre-treasury CFO, or finance leader and are...</h3>
+                        <h3>In this 30-minute session, we’ll show you how to:</h3>
                         <ul>
-                            <li>Tired of sitting through long demos</li>
-                            <li>Starting to think the selection process will never end</li>
-                            <li>Overwhelmed by the massive undertaking in front of you</li>
-                            <li>Concerned about having appropriate resources</li>
+                            <li>Focus your efforts before the show so you’re not overwhelmed by vendor demos</li>
+                            <li>Define and prioritize your real needs—whether you’re a first-time buyer or upgrading</li>
+                            <li>Avoid the 5 biggest mistakes treasury teams make when evaluating TMS options</li>
                         </ul>
-                        <p>We've got a fresh approach that will put an end to this misery.</p>
                     </div>
                     
                     <div class="hook-question">
@@ -585,7 +583,7 @@
                     
                     <div class="workshop-details">
                         <h3>🎯 FREE EXCLUSIVE WORKSHOP</h3>
-                        <p>Wednesday, Aug 27, 2025 | 3:00 PM ET</p>
+                        <p>Wednesday, Sep 24, 2025 | 2:00 PM ET</p>
                     </div>
                     
                     <a href="https://us06web.zoom.us/meeting/register/6p5i07BoScClgap0ZgqIDw" class="cta-button">🚀 END THE MISERY - JOIN NOW</a>


### PR DESCRIPTION
## Summary
- Update workshop page with September 24, 2025 date and new session description.
- Refresh site header banner to promote the updated workshop timing.

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68b992ed071083318e3ac85f14954072