### PR TITLE
Improve CTA card contrast for readability

### DIFF
--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -576,40 +576,43 @@
         }
 
         .cta-card {
-            background: rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.95);
             backdrop-filter: blur(20px);
-            border: 1px solid rgba(255, 255, 255, 0.2);
+            border: 1px solid rgba(0, 0, 0, 0.05);
             border-radius: 16px;
             padding: 32px 24px;
             text-decoration: none;
-            color: white;
+            color: var(--text);
             transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
             text-align: center;
         }
 
         .cta-card:hover {
-            background: rgba(255, 255, 255, 0.15);
+            background: #ffffff;
             transform: translateY(-3px);
-            color: white;
-            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+            color: var(--primary);
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
         }
 
         .cta-icon {
             font-size: 28px;
             margin-bottom: 16px;
             display: block;
+            color: var(--primary);
         }
 
         .cta-title {
             font-weight: 700;
             font-size: 18px;
             margin-bottom: 8px;
+            color: var(--primary);
         }
 
         .cta-desc {
             font-size: 14px;
             opacity: 0.8;
             font-weight: 500;
+            color: var(--text-light);
         }
 
         /* Responsive */


### PR DESCRIPTION
## Summary
- Increase readability of "Find Your Path" call-to-action cards with solid white backgrounds, dark base text, and purple accents for icons and titles

## Testing
- `npm install`
- `npm run build`
- `npm run test:ejs`


------
https://chatgpt.com/codex/tasks/task_e_68c0ca3293fc83318e49ff2112df7e54