### PR TITLE
Fix marketplace chart asset on TMS RFP Trap webinar page

### DIFF
--- a/webinar/tms-rfp-trap/index.html
+++ b/webinar/tms-rfp-trap/index.html
@@ -203,8 +203,8 @@ window.RTG_CONFIG = {
         <div class="rt-gv-container">
             <div id="rtGvContentRow" class="rt-gv-content-row">
             <div class="rt-gv-chart">
-                <p class="rt-gv-chart-label">The TMS RFP Trap — Featured Session</p>
-                <img src="https://i0.wp.com/realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png" alt="Featured content visual for The TMS RFP Trap session" loading="lazy">
+                <p class="rt-gv-chart-label">Treasury Tech Market Map — North America</p>
+                <img src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png" alt="Treasury Tech Market Map - North America" loading="lazy">
             </div>
             <div id="rtGvFormCard" class="rt-gv-form-card" role="region" aria-labelledby="rt-gv-form-heading">
                 <h3 id="rt-gv-form-heading" class="rt-gv-form-heading"></h3>


### PR DESCRIPTION
### Motivation
- Ensure the marketplace chart loads reliably in the TMS RFP Trap gated page and is correctly labeled for accessibility and clarity.

### Description
- Updated `webinar/tms-rfp-trap/index.html` to use the direct RealTreasury image URL instead of the `i0.wp.com` proxy and changed the chart caption and `alt` text to "Treasury Tech Market Map — North America".

### Testing
- Ran `npm install` which completed successfully.
- Ran `npm run build` which rendered site pages without errors.
- Ran `npm run test:ejs` which reported the installed EJS version and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea673d555483319b9f3777f70dd544)