### PR TITLE
Add top-level "On-Demand Video" nav item to header

### DIFF
--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -197,6 +197,12 @@ function add_my_custom_header_html() {
                         </div>
                     </div>
                 </div>
+                <!-- On-Demand Video -->
+                <div class="rt-nav-item">
+                    <a href="https://realtreasury.com/on-demand-workshop/" class="rt-nav-link">
+                        ON-DEMAND VIDEO
+                    </a>
+                </div>
                 <!-- About -->
                 <div class="rt-nav-item">
                     <a href="#" class="rt-nav-link has-dropdown">


### PR DESCRIPTION
### Motivation
- Surface the on-demand workshop as a primary navigation item so visitors can access it without waiting for banner interaction.
- Preserve the existing Services dropdown and any banner-based paths as alternate access points.

### Description
- Inserted a new `rt-nav-item` in `header/main-menu/custom-header.php` that adds an `ON-DEMAND VIDEO` link to `https://realtreasury.com/on-demand-workshop/` between the Services and About items.
- Left the Services dropdown content and journey steps unchanged.
- Change is a small HTML insertion (new navigation block) and does not modify other behavior or scripts.

### Testing
- Executed `npm install` which completed successfully.
- Executed `npm run build` which rendered the site pages without errors.
- Executed `npm run test:ejs` which reported EJS present and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6fe66268833192bbfe54a34b2f9f)