### PR TITLE
Add above-the-fold hero CTA for RFP on‑demand video

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -251,6 +251,27 @@
             flex-wrap: wrap;
         }
 
+        .hero-cta-module {
+            margin-top: 28px;
+            padding: 28px 30px;
+            max-width: 560px;
+        }
+
+        .hero-cta-module:hover,
+        .hero-cta-module:focus {
+            transform: none;
+        }
+
+        .hero-cta-module h3 {
+            margin-bottom: 12px;
+            font-size: 1.35rem;
+        }
+
+        .hero-cta-module p {
+            margin-bottom: 22px;
+            font-size: 1.05rem;
+        }
+
         .hero-image { 
             position: relative;
             animation: float 6s ease-in-out infinite;
@@ -980,6 +1001,11 @@
                 flex-direction: column;
                 align-items: center;
             }
+
+            .hero-cta-module {
+                margin: 24px auto 0;
+                text-align: left;
+            }
             
             .features-grid { 
                 grid-template-columns: 1fr; 
@@ -1111,6 +1137,11 @@
                     <div class="hero-buttons">
                         <a href="https://realtreasury.com/treasury-tech-portal/" class="btn btn-primary tpa-btn-ready">Access Portal</a>
                         <a href="#meet-the-team" class="btn btn-outline">Meet Our Team</a>
+                    </div>
+                    <div class="feature-card hero-cta-module">
+                        <h3>See the RFP workflow in action.</h3>
+                        <p>Get a quick walkthrough of how Real Treasury helps teams run a smarter, faster selection process.</p>
+                        <a href="https://realtreasury.com/rfp-on-demand-video/" class="btn btn-primary">Watch the RFP On-Demand Video</a>
                     </div>
                 </div>
                 <div class="hero-image">


### PR DESCRIPTION
### Motivation
- Add a clear, single-action CTA near the hero so visitors can quickly watch the RFP on‑demand video without leaving the fold when possible.
- Keep visual consistency by reusing existing card and button styles from the shared CSS rather than introducing new design tokens.

### Description
- Inserted a focused CTA card in `Homepage/index.html` directly below the hero buttons with action text “Watch the RFP On-Demand Video” linking to `https://realtreasury.com/rfp-on-demand-video/`.
- Reused existing `feature-card` container and `btn btn-primary` button styles for consistent visuals and accessibility.
- Added minimal scoped CSS rules for `.hero-cta-module` in `Homepage/index.html` to control spacing, typography, and mobile layout so the module sits above the fold on common viewports.
- Adjusted responsive rules so the CTA stacks and keeps readable spacing on smaller screens.

### Testing
- Ran `npm install` successfully.
- Ran `npm run build` which rendered site pages without errors.
- Ran `npm run test:ejs` which executed successfully and reported the installed EJS version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea706969a48331983cdd57e208d64b)