### PR TITLE
Replace homepage RFP hero card with single CTA button

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -251,25 +251,8 @@
             flex-wrap: wrap;
         }
 
-        .hero-cta-module {
+        .hero-rfp-button {
             margin-top: 28px;
-            padding: 28px 30px;
-            max-width: 560px;
-        }
-
-        .hero-cta-module:hover,
-        .hero-cta-module:focus {
-            transform: none;
-        }
-
-        .hero-cta-module h3 {
-            margin-bottom: 12px;
-            font-size: 1.35rem;
-        }
-
-        .hero-cta-module p {
-            margin-bottom: 22px;
-            font-size: 1.05rem;
         }
 
         .hero-image { 
@@ -1165,11 +1148,7 @@
                         <a href="https://realtreasury.com/treasury-tech-portal/" class="btn btn-primary tpa-btn-ready">Access Portal</a>
                         <a href="#meet-the-team" class="btn btn-outline">Meet Our Team</a>
                     </div>
-                    <div class="feature-card hero-cta-module">
-                        <h3>See the RFP workflow in action.</h3>
-                        <p>Get a quick walkthrough of how Real Treasury helps teams run a smarter, faster selection process.</p>
-                        <a href="https://realtreasury.com/rfp-on-demand-video/" class="btn btn-primary">Watch the RFP On-Demand Video</a>
-                    </div>
+                    <a href="https://realtreasury.com/rfp-on-demand-video/" class="btn btn-primary hero-rfp-button">Browse the RFP Video Library</a>
                 </div>
                 <div class="hero-image">
                     <div class="chart-carousel">


### PR DESCRIPTION
### Motivation
- Simplify the homepage hero so the RFP on-demand experience is a single clear CTA instead of a boxed card, making it easier for visitors to access the RFP video library.
- Support a shift toward a single entry point (the video library) where users can then choose from multiple on-demand videos.

### Description
- Removed the boxed `.feature-card.hero-cta-module` block and its copy from the hero section and replaced it with a single primary anchor button linking to the existing RFP on-demand page.
- Added a lightweight `.hero-rfp-button` CSS rule to provide spacing so the new CTA sits cleanly beneath the hero buttons.
- Preserved the original destination URL (`https://realtreasury.com/rfp-on-demand-video/`) so behavior remains consistent while simplifying the UI.

### Testing
- Ran `npm install` successfully.
- Built the site with `npm run build` and the build completed without errors.
- Ran the EJS check with `npm run test:ejs` which reported `EJS installed: 3.1.10` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea748a132883319c7d3acdaadee247)