### PR TITLE
Update ERR NOT second R step to RFI

### DIFF
--- a/errnot/index.html
+++ b/errnot/index.html
@@ -415,10 +415,10 @@
                     </ul>
                 </div>
 
-                <!-- Step 3: RFI/RFP -->
+                <!-- Step 3: RFI -->
                 <div class="glass-card rounded-2xl p-8 text-center relative">
                     <div class="step-number">R</div>
-                    <h3 class="text-2xl font-bold mb-4">RFI/RFP</h3>
+                    <h3 class="text-2xl font-bold mb-4">RFI</h3>
                     <ul class="text-left space-y-3 text-gray-600">
                         <li class="flex items-start">
                             <span class="text-purple-600 mr-2">•</span>

--- a/insights/2024/real-treasury-explained/index.html
+++ b/insights/2024/real-treasury-explained/index.html
@@ -772,7 +772,7 @@
 
                 <div class="err-not-card">
                     <span class="err-not-letter">R</span>
-                    <div class="err-not-word">RFI/RFP</div>
+                    <div class="err-not-word">RFI</div>
                     <p class="err-not-description">Focused questions that matter. Cut through the noise and get answers that differentiate vendors.</p>
                 </div>
 

--- a/treasury-tech-selection/workshop/index.html
+++ b/treasury-tech-selection/workshop/index.html
@@ -708,8 +708,8 @@
                 
                 <div class="card">
                     <div class="card-letter">R</div>
-                    <h3>✅ RFI/RFP</h3>
-                    <p>Create BESPOKE RFI/RFP documents designed to effectively shortlist the RIGHT vendors for YOUR needs.</p>
+                    <h3>✅ RFI</h3>
+                    <p>Create BESPOKE RFI documents designed to effectively shortlist the RIGHT vendors for YOUR needs.</p>
                 </div>
                 
                 <div class="card">


### PR DESCRIPTION
## Summary
- replaced ERR NOT step label `RFI/RFP` with `RFI` on ERR NOT-related pages
- updated the workshop ERR NOT card copy to remove RFP references (`BESPOKE RFI documents`)
- adjusted an in-page step comment to match the new step name

## Files changed
- `errnot/index.html`
- `insights/2024/real-treasury-explained/index.html`
- `treasury-tech-selection/workshop/index.html`

## Validation
- verified staged diff only contains ERR NOT step terminology updates
- did not run build/test commands for this copy-only change

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee6edcba548331b1de0b54051a945b)