### PR TITLE
Update Services banner copy and split webinar CTAs for registration vs recording

### DIFF
--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -156,14 +156,17 @@ function add_my_custom_header_html() {
                                             <span class="rt-service-cta">Request Access →</span>
                                         </a>
 
-                                        <a href="https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04" target="_blank" rel="noopener noreferrer" class="rt-service-item">
+                                        <div class="rt-service-item">
                                             <div class="rt-service-header">
                                                 <div class="rt-service-icon">▶️</div>
-                                                <div class="rt-service-title">From Prompt to Product + On-Demand</div>
+                                                <div class="rt-service-title">From Prompt to Product: Build or Buy?</div>
                                             </div>
-                                            <div class="rt-service-desc">Explore whether treasury should build its own tools or buy: tradeoffs in speed, cost, control, scalability, support, and risk.</div>
-                                            <span class="rt-service-cta">Register Now →</span>
-                                        </a>
+                                            <div class="rt-service-desc">Should treasury build its own tools? Compare speed, cost, control, scalability, support, and risk in this live webinar.</div>
+                                            <div class="rt-service-cta-group">
+                                                <a href="https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04" target="_blank" rel="noopener noreferrer" class="rt-service-cta">Register Live →</a>
+                                                <a href="https://realtreasury.com/on-demand-workshop/" class="rt-service-cta">Watch Recording →</a>
+                                            </div>
+                                        </div>
 
                                         <a href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2?ismsaljsauthenabled" target="_blank" class="rt-service-item">
                                             <div class="rt-service-header">


### PR DESCRIPTION
### Motivation
- Align the Services menu webinar banner with the current Teams event topic and make both registration and recording actions clearly available in the same card.
- Prevent user confusion by making the primary CTA go to the live registration page and adding an explicit secondary CTA to the on-demand recording page.

### Description
- Updated `header/main-menu/custom-header.php` to change the webinar card title to `From Prompt to Product: Build or Buy?` and refreshed the supporting description to match the build-vs-buy focus.
- Replaced the single registration-only service link block with a service item that contains two CTAs: a primary `Register Live →` linking to the Teams event URL and a secondary `Watch Recording →` linking to the on-demand workshop page.
- Kept the Journey step for the webinar pointing to the live Teams registration URL and verified the Teams event ID is the current one used in the file.

### Testing
- Searched and inspected webinar copy and CTAs with `rg -n "From Prompt to Product|Register Now|On-Demand|Register Live|Watch Recording|rt-service-cta" header/main-menu/custom-header.php` and confirmed updated strings are present.
- Scanned for Teams event IDs with `rg -n "b9f9620f-fdcf-4888-804c-bb08220b34e0|events\.teams\.microsoft\.com/event/"` and confirmed the repository contains the expected current event ID only.
- Run project checks `npm install`, `npm run build`, and `npm run test:ejs` and verified they completed successfully.
- Note: visual/browser rendering was not captured because no browser-container screenshot tool was available in this environment, so UI behavior was validated by inspecting the generated markup only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef70d0652883319e6ee56d754702c6)