### PR TITLE
Align webinar banner in main-menu/index.html with PHP header menu

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -445,17 +445,21 @@ body.banner-minimized .rt-nav-container {
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Reminder: Watch the workshop on demand</span>
+                    <span class="banner-highlight">From Prompt to Product: Build or Buy?</span>
                 </div>
                 <div class="banner-subtitle">
-                    Quick refresher available anytime.
+                    Should treasury build its own tools? Compare speed, cost, control, scalability, support, and risk in this live webinar.
                 </div>
             </div>
         </div>
 
         <div class="banner-actions">
-            <a href="https://realtreasury.com/on-demand-workshop/" class="banner-cta" onclick="watchOnDemand(event)">
-                Watch now
+            <a href="https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04" target="_blank" rel="noopener noreferrer" class="banner-cta" onclick="registerLive(event)">
+                Register Live
+                <span>→</span>
+            </a>
+            <a href="https://realtreasury.com/on-demand-workshop/" class="banner-cta" onclick="watchRecording(event)">
+                Watch Recording
                 <span>→</span>
             </a>
         </div>
@@ -464,6 +468,7 @@ body.banner-minimized .rt-nav-container {
     <div class="site-content"></div>
 
 <script>
+const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04';
 const ON_DEMAND_WORKSHOP_URL = 'https://realtreasury.com/on-demand-workshop/';
 
 // Add banner state management
@@ -517,18 +522,23 @@ function expandBanner(event) {
         return;
     }
 
-    // Navigate to the on-demand workshop page
-    window.location.href = ON_DEMAND_WORKSHOP_URL;
+    // Open live webinar registration by default when expanding the banner
+    window.open(LIVE_WEBINAR_REGISTRATION_URL, "_blank", "noopener,noreferrer");
 }
 
-function watchOnDemand(event) {
+function registerLive(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    // Open live webinar registration in a new tab
+    window.open(LIVE_WEBINAR_REGISTRATION_URL, "_blank", "noopener,noreferrer");
+}
+
+function watchRecording(event) {
     event.preventDefault();
     event.stopPropagation();
     // Navigate in the current tab to on-demand workshop
     window.location.href = ON_DEMAND_WORKSHOP_URL;
 }
-
-
 
 function isMobileDevice() {
     return window.innerWidth <= 768 || /android|iphone|ipad|ipod|iemobile|blackberry|bada/i.test(


### PR DESCRIPTION
### Motivation
- Make the static `header/main-menu/index.html` workshop/banner copy and CTAs match the already-updated PHP header (`header/main-menu/custom-header.php`).
- Ensure the visible CTAs include both live registration and on-demand recording so users can register or watch the recording.
- Make banner interactions open the live registration by default when expanded and keep the on-demand recording link available.

### Description
- Updated `header/main-menu/index.html` banner title to `From Prompt to Product: Build or Buy?` and changed the subtitle to the build-vs-buy framing used in the PHP header. 
- Added two visible CTAs in the banner: `Register Live →` linking to the Teams registration URL (`https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04`) and `Watch Recording →` linking to the on-demand page (`https://realtreasury.com/on-demand-workshop/`).
- Introduced `LIVE_WEBINAR_REGISTRATION_URL` constant and new JS handlers `registerLive(event)` and `watchRecording(event)`, updated `expandBanner` to open the registration URL by default, and wired the banner CTA `onclick` attributes to the new handlers.
- Removed the previous on-demand-only copy and ensured no stale CTA phrasing remains in the updated file, and verified parity of title/description/CTA URLs with `header/main-menu/custom-header.php`.

### Testing
- Ran targeted content searches with `rg` to confirm the new title, subtitle, and both CTA URLs are present and that stale phrases like `Register Now` or `+ On-Demand` are absent, and confirmed parity with `custom-header.php` (searches succeeded). 
- Ran `npm run build` to render pages and confirm no build errors (succeeded). 
- Ran `npm run test:ejs` to verify EJS availability (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef727d8a1c8331ab6bf1a900d1a4da)