### PR TITLE
Make webinar banner a single, unambiguous registration CTA

### DIFF
--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -163,8 +163,7 @@ function add_my_custom_header_html() {
                                             </div>
                                             <div class="rt-service-desc">Should treasury build its own tools? Compare speed, cost, control, scalability, support, and risk in this live webinar.</div>
                                             <div class="rt-service-cta-group">
-                                                <a href="https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04" target="_blank" rel="noopener noreferrer" class="rt-service-cta">Register Live →</a>
-                                                <a href="https://realtreasury.com/on-demand-workshop/" class="rt-service-cta">Watch Recording →</a>
+                                                <a href="https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04" target="_blank" rel="noopener noreferrer" class="rt-service-cta">Register for Upcoming Webinar →</a>
                                             </div>
                                         </div>
 

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -455,11 +455,7 @@ body.banner-minimized .rt-nav-container {
 
         <div class="banner-actions">
             <a href="https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04" target="_blank" rel="noopener noreferrer" class="banner-cta" onclick="registerLive(event)">
-                Register Live
-                <span>→</span>
-            </a>
-            <a href="https://realtreasury.com/on-demand-workshop/" class="banner-cta" onclick="watchRecording(event)">
-                Watch Recording
+                Register for Upcoming Webinar
                 <span>→</span>
             </a>
         </div>
@@ -469,7 +465,6 @@ body.banner-minimized .rt-nav-container {
 
 <script>
 const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/b9f9620f-fdcf-4888-804c-bb08220b34e0@cdc422ca-d271-4ba3-856d-77081c6a7f04';
-const ON_DEMAND_WORKSHOP_URL = 'https://realtreasury.com/on-demand-workshop/';
 
 // Add banner state management
 function updateBannerState() {
@@ -531,13 +526,6 @@ function registerLive(event) {
     event.stopPropagation();
     // Open live webinar registration in a new tab
     window.open(LIVE_WEBINAR_REGISTRATION_URL, "_blank", "noopener,noreferrer");
-}
-
-function watchRecording(event) {
-    event.preventDefault();
-    event.stopPropagation();
-    // Navigate in the current tab to on-demand workshop
-    window.location.href = ON_DEMAND_WORKSHOP_URL;
 }
 
 function isMobileDevice() {


### PR DESCRIPTION
### Motivation
- The top workshop/banner area presented both a registration and a recording/on‑demand link, creating ambiguous primary actions for users.
- The intent is to prioritize upcoming webinar registration in the global banner while preventing users from being forced to choose between registering and watching the recording at the top of the site.

### Description
- Updated `header/main-menu/index.html` to remove the secondary "Watch Recording" CTA and changed the remaining CTA label to `Register for Upcoming Webinar` while keeping the live registration URL as the target.
- Removed the `ON_DEMAND_WORKSHOP_URL` constant and the `watchRecording` handler from the banner script so the banner only supports registration navigation (`LIVE_WEBINAR_REGISTRATION_URL` remains).
- Updated the services panel variant in `header/main-menu/custom-header.php` to use the same single registration CTA copy and removed the hardcoded recording link there as well.
- Preserved banner state and click/expand behavior so expanding the banner still opens the registration link in a new tab via `registerLive`/`expandBanner`.

### Testing
- Ran `npm install` and dependency install completed successfully.
- Ran `npm run build` and the static site renderer completed successfully, producing updated pages (build output shows rendered pages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b0ed50848331900563ed6bb19eb7)