### PR TITLE
Replace ON-DEMAND VIDEO nav entry with WEBINARS

### DIFF
--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -200,10 +200,10 @@ function add_my_custom_header_html() {
                         </div>
                     </div>
                 </div>
-                <!-- On-Demand Video -->
+                <!-- Webinars -->
                 <div class="rt-nav-item">
-                    <a href="https://realtreasury.com/on-demand-workshop/" class="rt-nav-link">
-                        ON-DEMAND VIDEO
+                    <a href="https://realtreasury.com/webinars/" class="rt-nav-link">
+                        WEBINARS
                     </a>
                 </div>
                 <!-- About -->


### PR DESCRIPTION
## Summary
- removed the separate `ON-DEMAND VIDEO` top-level nav item
- kept `WEBINARS` as the single top-level item in that position in the primary header nav
- this effectively replaces the previous nav slot with the `WEBINARS` destination

## Validation
- no runtime checks executed (targeted markup-only adjustment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c89cf0b083318ec91ee88c1f5547)