### PR TITLE
Broaden webinar feed matching and add resilient fallback

### DIFF
--- a/templates/webinars/index.html
+++ b/templates/webinars/index.html
@@ -508,7 +508,7 @@
 
             const wordpressOrigin = determineWordPressOrigin();
             const webinarApiUrl = `${wordpressOrigin}/wp-json/wp/v2/posts?_embed&per_page=100&include_no_featured=1`;
-            const webinarKeywords = ['webinar','recording','on-demand'];
+            const webinarKeywords = ['webinar', 'webinars', 'recording', 'recordings', 'on-demand', 'ondemand', 'workshop', 'workshops'];
 
             let allPosts = [];
             let currentPosts = [];
@@ -604,23 +604,35 @@
 
                     const posts = await webinarResponse.json();
 
-                    const mappedPosts = posts
-                        .filter(post => {
-                            const haystack = `${post.title?.rendered || ''} ${post.excerpt?.rendered || ''}`.toLowerCase();
-                            return webinarKeywords.some(keyword => haystack.includes(keyword));
-                        })
-                        .map(post => ({
-                            id: post.id,
-                            title: post.title.rendered,
-                            excerpt: buildExcerpt(post),
-                            image: post._embedded?.['wp:featuredmedia']?.[0]?.source_url || 'https://realtreasury.com/images/treasury-tech-real-estate-og.jpg',
-                            category: post._embedded?.['wp:term']?.[0]?.[0]?.name || 'Webinar',
-                            meta: new Date(post.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-                            link: post.link,
-                            cta: /recording|on-demand/i.test(`${post.title} ${post.excerpt.rendered}`) ? 'Watch Recording' : 'View Webinar'
-                        }));
+                    const mapPost = (post) => ({
+                        id: post.id,
+                        title: post.title?.rendered || 'Untitled',
+                        excerpt: buildExcerpt(post),
+                        image: post._embedded?.['wp:featuredmedia']?.[0]?.source_url || 'https://realtreasury.com/images/treasury-tech-real-estate-og.jpg',
+                        category: post._embedded?.['wp:term']?.[0]?.[0]?.name || 'Webinar',
+                        meta: new Date(post.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
+                        link: (post.link || '').trim(),
+                        cta: /recording|on-demand|workshop/i.test(`${post.title?.rendered || ''} ${post.excerpt?.rendered || ''}`) ? 'Watch Recording' : 'View Webinar'
+                    });
 
-                    allPosts = mappedPosts.filter((item, idx, arr) => idx === arr.findIndex(x => x.link === item.link));
+                    const validPosts = posts.filter(post => (post.link || '').trim().length > 0);
+                    const matchedPosts = validPosts.filter(post => {
+                        const termNames = (post._embedded?.['wp:term'] || [])
+                            .flat()
+                            .map(term => term?.name || '')
+                            .join(' ');
+                        const haystack = `${post.title?.rendered || ''} ${post.excerpt?.rendered || ''} ${post.slug || ''} ${termNames}`.toLowerCase();
+                        return webinarKeywords.some(keyword => haystack.includes(keyword));
+                    });
+
+                    let mappedPosts = matchedPosts.map(mapPost);
+                    if (mappedPosts.length === 0) {
+                        const fallbackCount = Math.min(12, Math.max(6, POSTS_PER_PAGE));
+                        console.warn(`No webinar/workshop keyword matches found in feed; falling back to latest ${fallbackCount} posts. Please review taxonomy/terms.`);
+                        mappedPosts = validPosts.slice(0, fallbackCount).map(mapPost);
+                    }
+
+                    allPosts = mappedPosts.filter((item, idx, arr) => item.link && idx === arr.findIndex(x => x.link === item.link));
                     currentPosts = allPosts;
                     displayedCount = POSTS_PER_PAGE;
                     displayPosts(currentPosts.slice(0, displayedCount));

--- a/webinars/index.html
+++ b/webinars/index.html
@@ -508,7 +508,7 @@
 
             const wordpressOrigin = determineWordPressOrigin();
             const webinarApiUrl = `${wordpressOrigin}/wp-json/wp/v2/posts?_embed&per_page=100&include_no_featured=1`;
-            const webinarKeywords = ['webinar','recording','on-demand'];
+            const webinarKeywords = ['webinar', 'webinars', 'recording', 'recordings', 'on-demand', 'ondemand', 'workshop', 'workshops'];
 
             let allPosts = [];
             let currentPosts = [];
@@ -604,23 +604,35 @@
 
                     const posts = await webinarResponse.json();
 
-                    const mappedPosts = posts
-                        .filter(post => {
-                            const haystack = `${post.title?.rendered || ''} ${post.excerpt?.rendered || ''}`.toLowerCase();
-                            return webinarKeywords.some(keyword => haystack.includes(keyword));
-                        })
-                        .map(post => ({
-                            id: post.id,
-                            title: post.title.rendered,
-                            excerpt: buildExcerpt(post),
-                            image: post._embedded?.['wp:featuredmedia']?.[0]?.source_url || 'https://realtreasury.com/images/treasury-tech-real-estate-og.jpg',
-                            category: post._embedded?.['wp:term']?.[0]?.[0]?.name || 'Webinar',
-                            meta: new Date(post.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-                            link: post.link,
-                            cta: /recording|on-demand/i.test(`${post.title} ${post.excerpt.rendered}`) ? 'Watch Recording' : 'View Webinar'
-                        }));
+                    const mapPost = (post) => ({
+                        id: post.id,
+                        title: post.title?.rendered || 'Untitled',
+                        excerpt: buildExcerpt(post),
+                        image: post._embedded?.['wp:featuredmedia']?.[0]?.source_url || 'https://realtreasury.com/images/treasury-tech-real-estate-og.jpg',
+                        category: post._embedded?.['wp:term']?.[0]?.[0]?.name || 'Webinar',
+                        meta: new Date(post.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
+                        link: (post.link || '').trim(),
+                        cta: /recording|on-demand|workshop/i.test(`${post.title?.rendered || ''} ${post.excerpt?.rendered || ''}`) ? 'Watch Recording' : 'View Webinar'
+                    });
 
-                    allPosts = mappedPosts.filter((item, idx, arr) => idx === arr.findIndex(x => x.link === item.link));
+                    const validPosts = posts.filter(post => (post.link || '').trim().length > 0);
+                    const matchedPosts = validPosts.filter(post => {
+                        const termNames = (post._embedded?.['wp:term'] || [])
+                            .flat()
+                            .map(term => term?.name || '')
+                            .join(' ');
+                        const haystack = `${post.title?.rendered || ''} ${post.excerpt?.rendered || ''} ${post.slug || ''} ${termNames}`.toLowerCase();
+                        return webinarKeywords.some(keyword => haystack.includes(keyword));
+                    });
+
+                    let mappedPosts = matchedPosts.map(mapPost);
+                    if (mappedPosts.length === 0) {
+                        const fallbackCount = Math.min(12, Math.max(6, POSTS_PER_PAGE));
+                        console.warn(`No webinar/workshop keyword matches found in feed; falling back to latest ${fallbackCount} posts. Please review taxonomy/terms.`);
+                        mappedPosts = validPosts.slice(0, fallbackCount).map(mapPost);
+                    }
+
+                    allPosts = mappedPosts.filter((item, idx, arr) => item.link && idx === arr.findIndex(x => x.link === item.link));
                     currentPosts = allPosts;
                     displayedCount = POSTS_PER_PAGE;
                     displayPosts(currentPosts.slice(0, displayedCount));


### PR DESCRIPTION
### Motivation
- Prevent the webinars library from showing an empty state when webinar/workshop content exists in the WP feed but is not detected by a narrow keyword filter.
- Make the client-side matcher more robust to varied taxonomy, slug and content formats (including workshop variants and plurals).

### Description
- Expanded the keyword list to include plural and workshop variants and updated CTA detection to recognize `workshop` patterns.
- Replaced the old `filter(...).map(...)` logic in `fetchPosts()` with matching that searches `post.title.rendered`, `post.excerpt.rendered`, `post.slug`, and category/tag names from `_embedded['wp:term']` before mapping.
- Added guardrails to drop posts with empty `link` values and deduplicate the rendered list by canonical `link`.
- Implemented a fallback that, if no matches are found, logs a console warning and renders a recent set of posts (bounded between 6 and 12) from the same API response; changes were applied to both `templates/webinars/index.html` and the mirrored `webinars/index.html`.

### Testing
- Ran `npm install` which completed successfully.
- Ran `npm run build` which rendered the site and produced `webinars/index.html` successfully.
- Ran `npm run test:ejs` which reported the installed EJS version and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c91f1d3c8331a580dc957c092bfa)