### PR TITLE
Remove homepage webinar hero button

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -251,10 +251,6 @@
             flex-wrap: wrap;
         }
 
-        .hero-rfp-button {
-            margin-top: 28px;
-        }
-
         .hero-image { 
             position: relative;
             animation: float 6s ease-in-out infinite;
@@ -1148,7 +1144,6 @@
                         <a href="https://realtreasury.com/treasury-tech-portal/" class="btn btn-primary tpa-btn-ready">Access Portal</a>
                         <a href="#meet-the-team" class="btn btn-outline">Meet Our Team</a>
                     </div>
-                    <a href="https://realtreasury.com/webinar-tms-rfp-trap/" class="btn btn-primary hero-rfp-button">Watch Our Latest Webinar</a>
                 </div>
                 <div class="hero-image">
                     <div class="chart-carousel">


### PR DESCRIPTION
### Motivation
- The webinar CTA is now available in the main navigation, making the standalone "Watch Our Latest Webinar" button in the homepage hero redundant.

### Description
- Removed the standalone webinar anchor and label from `Homepage/index.html` and removed the unused `.hero-rfp-button` CSS rule.

### Testing
- Ran `npm install` and `npm run build`, both completed successfully with the site rendered without build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d810b8b08331a6714316a537a056)