### PR TITLE
Update North American market map image URL across all placements

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -1126,7 +1126,7 @@
                                     <h3>Treasury Systems</h3>
                                     <p>North American Vendors</p>
                                 </div>
-                                <img src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png" alt="Treasury Tech Market Map - North America">
+                                <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-NORAM-05-2026-clean.png" alt="Treasury Tech Market Map - North America">
                             </a>
                         </div>
                         <div class="chart-slide">

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -39,7 +39,7 @@ function add_my_custom_header_html() {
                                                     <p>North America</p>
                                                 </div>
                                                 <img class="rt-explore-image"
-                                                    src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png"
+                                                    src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-NORAM-05-2026-clean.png"
                                                      alt="Treasury Tech Market - North America">
                                             </a>
                                         </div>

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -706,7 +706,7 @@
                             <h3>Treasury Systems</h3>
                             <p>North American Vendors</p>
                         </div>
-                        <img src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png" alt="Treasury Tech Market Map - North America" loading="lazy">
+                        <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-NORAM-05-2026-clean.png" alt="Treasury Tech Market Map - North America" loading="lazy">
                     </div>
                     <div class="market-image">
                         <div class="chart-title-overlay-large">

--- a/webinars/3-segments-1-smart-choice/index.html
+++ b/webinars/3-segments-1-smart-choice/index.html
@@ -204,7 +204,7 @@ window.RTG_CONFIG = {
             <div id="rtGvContentRow" class="rt-gv-content-row">
             <div class="rt-gv-chart">
                 <p class="rt-gv-chart-label">TMS Market Landscape — North America</p>
-                <img src="https://i0.wp.com/realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png" alt="TMS Market Landscape - North America, January 2026" loading="lazy">
+                <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-NORAM-05-2026-clean.png" alt="TMS Market Landscape - North America, January 2026" loading="lazy">
             </div>
             <div id="rtGvFormCard" class="rt-gv-form-card" role="region" aria-labelledby="rt-gv-form-heading">
                 <h3 id="rt-gv-form-heading" class="rt-gv-form-heading"></h3>

--- a/webinars/tms-rfp-trap/index.html
+++ b/webinars/tms-rfp-trap/index.html
@@ -204,7 +204,7 @@ window.RTG_CONFIG = {
             <div id="rtGvContentRow" class="rt-gv-content-row">
             <div class="rt-gv-chart">
                 <p class="rt-gv-chart-label">Treasury Tech Market Map — North America</p>
-                <img src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-NORAM-01-2026-clean-2.png" alt="Treasury Tech Market Map - North America" loading="lazy">
+                <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-NORAM-05-2026-clean.png" alt="Treasury Tech Market Map - North America" loading="lazy">
             </div>
             <div id="rtGvFormCard" class="rt-gv-form-card" role="region" aria-labelledby="rt-gv-form-heading">
                 <h3 id="rt-gv-form-heading" class="rt-gv-form-heading"></h3>


### PR DESCRIPTION
## Summary
Updated the North American chart image URL to the new asset across all known page/header placements.

## Changes made
- Replaced the old NORAM image URL with:
  - `https://realtreasury.com/wp-content/uploads/2026/05/tms-market-NORAM-05-2026-clean.png`
- Updated in:
  - `Homepage/index.html`
  - `header/main-menu/custom-header.php`
  - `treasury-tech-market/index.html`
  - `webinars/tms-rfp-trap/index.html`
  - `webinars/3-segments-1-smart-choice/index.html`

## Validation
- Searched the updated files to confirm they now reference the new URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066a32f67c8331a5e0d7531f0c55fe)