### PR TITLE
Move 2026 waitlist landing page into insights

### DIFF
--- a/insights/2026/real-treasury-tech-selection-guide-waitlist/index.html
+++ b/insights/2026/real-treasury-tech-selection-guide-waitlist/index.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>2026 Real Treasury Tech Selection Guide | Waitlist</title>
+  <meta name="description" content="Join the waitlist for the 2026 Real Treasury Tech Selection Guide and get notified as soon as it launches." />
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #111827;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --brand: #22c55e;
+      --brand-dark: #16a34a;
+      --border: #1f2937;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(circle at top right, #1e293b, var(--bg));
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 1.5rem;
+    }
+    .wrap {
+      width: 100%;
+      max-width: 860px;
+      display: grid;
+      grid-template-columns: 1.2fr 1fr;
+      gap: 1rem;
+    }
+    .card {
+      background: color-mix(in srgb, var(--panel) 92%, #000);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 1.5rem;
+      box-shadow: 0 8px 30px rgba(0,0,0,.35);
+    }
+    h1 { margin: 0 0 .75rem; font-size: clamp(1.6rem, 2.5vw, 2.5rem); line-height: 1.15; }
+    p { color: var(--muted); line-height: 1.6; }
+    .pill {
+      display: inline-block;
+      font-size: .8rem;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      border: 1px solid #334155;
+      border-radius: 999px;
+      padding: .35rem .65rem;
+      margin-bottom: .75rem;
+      color: #cbd5e1;
+    }
+    ul { padding-left: 1.1rem; color: var(--muted); }
+    li { margin-bottom: .5rem; }
+
+    form { display: grid; gap: .85rem; }
+    label { font-weight: 600; font-size: .95rem; }
+    input, textarea {
+      width: 100%;
+      border: 1px solid #374151;
+      border-radius: 10px;
+      background: #0b1220;
+      color: var(--text);
+      padding: .75rem .8rem;
+      font: inherit;
+    }
+    input:focus, textarea:focus { outline: 2px solid #14532d; border-color: var(--brand); }
+    button {
+      border: 0;
+      border-radius: 10px;
+      background: var(--brand);
+      color: #052e16;
+      padding: .85rem 1rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button:hover { background: var(--brand-dark); color: #ecfdf5; }
+    .small { font-size: .8rem; color: #94a3b8; margin-top: .2rem; }
+
+    @media (max-width: 860px) {
+      .wrap { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="card">
+      <span class="pill">Coming in 2026</span>
+      <h1>Join the Waitlist for the 2026 Real Treasury Tech Selection Guide</h1>
+      <p>
+        Be the first to access our upcoming 2026 guide with practical selection criteria,
+        vendor evaluation framework, and implementation insights.
+      </p>
+      <ul>
+        <li>Early release notification</li>
+        <li>Actionable selection scorecards</li>
+        <li>Independent, practitioner-led guidance</li>
+      </ul>
+    </section>
+
+    <section class="card" aria-labelledby="waitlist-form-title">
+      <h2 id="waitlist-form-title" style="margin-top:0">Reserve Your Spot</h2>
+      <!--
+        Uses FormSubmit for no-code handling:
+        - Sends submission email notification to contact@realtreasury.com
+        - Sends autoresponder confirmation to the person who submitted the form
+      -->
+      <form action="https://formsubmit.co/contact@realtreasury.com" method="POST">
+        <input type="hidden" name="_subject" value="New 2026 Selection Guide Waitlist Signup" />
+        <input type="hidden" name="_captcha" value="false" />
+        <input type="hidden" name="_template" value="table" />
+        <input type="hidden" name="_autoresponse" value="Thanks for joining the waitlist. You are officially on the list for the 2026 Real Treasury Tech Selection Guide. We’ll email you when it launches." />
+
+        <div>
+          <label for="name">Full Name</label>
+          <input id="name" name="name" autocomplete="name" required />
+        </div>
+
+        <div>
+          <label for="email">Work Email</label>
+          <input id="email" name="email" type="email" autocomplete="email" required />
+        </div>
+
+        <div>
+          <label for="company">Company</label>
+          <input id="company" name="company" autocomplete="organization" />
+        </div>
+
+        <div>
+          <label for="notes">Notes (Optional)</label>
+          <textarea id="notes" name="notes" rows="3" placeholder="Anything specific you want covered in the guide?"></textarea>
+        </div>
+
+        <button type="submit">Join the Waitlist</button>
+        <p class="small">By submitting, you agree to receive this waitlist confirmation and related launch updates.</p>
+      </form>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- moved the 2026 waitlist landing page from `treasury-tech-selection/2026-selection-guide-waitlist/` to `insights/2026/real-treasury-tech-selection-guide-waitlist/`
- preserved page content and form behavior unchanged

## Why
- aligns placement with the insights content structure as requested

## Notes
- if any internal links or menu entries were already pointing to the old path, they should be updated to the new URL path

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0759245fe4833194382db752cd3f09)