### PR TITLE
Create canonical reusable waitlist confirmation page for treasury tech guide

### DIFF
--- a/insights/2026/real-treasury-tech-selection-guide-waitlist/index.html
+++ b/insights/2026/real-treasury-tech-selection-guide-waitlist/index.html
@@ -114,13 +114,16 @@
 
         Keep this trigger for static previews. In WordPress with the plugin active,
         clicking this opens the rt-gate modal and submits via the configured CF7 form.
+
+        Recommended rt-gate / CF7 redirect URL:
+        /waitlist/treasury-tech-selection-guide/?guide=Real%20Treasury%20Tech%20Selection%20Guide&year=2026
       -->
       <a href="#openPortalModal" class="tpa-btn open-portal-modal" data-portal-trigger data-asset="2026-selection-guide-waitlist">
         <button type="button">Join the Waitlist</button>
       </a>
 
       <p class="small">
-        By submitting through the gate form, you will receive confirmation and waitlist updates.
+        By submitting through the gate form, you will receive confirmation and waitlist updates at /waitlist/treasury-tech-selection-guide/.
       </p>
     </section>
   </main>

--- a/insights/2026/treasury-tech-selection-guide/index.html
+++ b/insights/2026/treasury-tech-selection-guide/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=/waitlist/treasury-tech-selection-guide/" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Moved: Treasury Tech Selection Guide Waitlist Confirmation</title>
+</head>
+<body>
+  <!-- Deprecated path: canonical reusable confirmation page now lives at /waitlist/treasury-tech-selection-guide/. -->
+  <p>This confirmation page moved to <a href="/waitlist/treasury-tech-selection-guide/">/waitlist/treasury-tech-selection-guide/</a>.</p>
+</body>
+</html>

--- a/waitlist/treasury-tech-selection-guide/index.html
+++ b/waitlist/treasury-tech-selection-guide/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Waitlist Confirmation | Real Treasury</title>
+  <meta name="description" content="Waitlist confirmation page for Real Treasury guides." />
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #111827;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --brand: #22c55e;
+      --border: #1f2937;
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: radial-gradient(circle at top right, #1e293b, var(--bg));
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 1rem;
+    }
+    .card {
+      width: 100%;
+      max-width: 760px;
+      background: color-mix(in srgb, var(--panel) 92%, #000);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 1.5rem;
+      box-shadow: 0 8px 30px rgba(0,0,0,.35);
+    }
+    .pill {
+      display: inline-block;
+      font-size: .78rem;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      border: 1px solid #334155;
+      border-radius: 999px;
+      padding: .35rem .65rem;
+      margin-bottom: .9rem;
+      color: #cbd5e1;
+    }
+    h1 { margin: 0 0 .6rem; font-size: clamp(1.4rem, 2.8vw, 2.3rem); line-height: 1.2; }
+    p { margin: 0.6rem 0; color: var(--muted); line-height: 1.6; }
+    .guide-title { color: #ecfdf5; }
+    .next-steps { margin-top: 1rem; }
+    .next-steps li { margin-bottom: .45rem; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <main class="card" aria-live="polite">
+    <span id="campaign-pill" class="pill">Waitlist Confirmed</span>
+    <h1>You’re on the waitlist for the <span id="guide-title" class="guide-title">Real Treasury Tech Selection Guide</span>.</h1>
+    <p>Thanks for signing up. We’ll notify you as soon as this guide is released.</p>
+    <ul class="next-steps">
+      <li>Watch your email for launch details.</li>
+      <li>Add Real Treasury to your safe sender list so updates do not get filtered.</li>
+    </ul>
+  </main>
+
+  <script>
+    (function () {
+      var params = new URLSearchParams(window.location.search || '');
+      var rawGuide = params.get('guide');
+      var rawYear = params.get('year');
+
+      var defaultGuide = 'Real Treasury Tech Selection Guide';
+      var safeGuide = (rawGuide || defaultGuide).trim().slice(0, 120);
+      if (!safeGuide) safeGuide = defaultGuide;
+
+      var guideTitleEl = document.getElementById('guide-title');
+      if (guideTitleEl) {
+        guideTitleEl.textContent = safeGuide;
+      }
+
+      var year = (rawYear || '').trim();
+      var yearMatch = year.match(/^\d{4}$/);
+      var pillEl = document.getElementById('campaign-pill');
+      if (pillEl && yearMatch) {
+        pillEl.textContent = yearMatch[0] + ' Campaign · Waitlist Confirmed';
+      }
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a reusable, top-level confirmation page for gated guide waitlists outside `insights/` so the same confirmation UI can be reused across campaigns.
- Replace hard-coded year/title copy with evergreen, iframe-safe markup and a small runtime that accepts safe overrides via URL query parameters.
- Centralize the canonical redirect target for rt-gate / CF7 flows so per-campaign entry pages can point to a single confirmation URL.
- Preserve a legacy path with a clear deprecation redirect and note so future editors can find the canonical location.

### Description

- Added a self-contained confirmation page at `waitlist/treasury-tech-selection-guide/index.html` that contains inline CSS/HTML and a small script to support `?guide=` and `?year=` query overrides with safe defaults and input trimming.
- Created a lightweight redirect/deprecation stub at `insights/2026/treasury-tech-selection-guide/index.html` that immediately redirects to the canonical waitlist path and documents the move.
- Updated `insights/2026/real-treasury-tech-selection-guide-waitlist/index.html` to recommend the new canonical redirect URL and to update the confirmation text to point to `/waitlist/treasury-tech-selection-guide/`.
- Ensured the new confirmation page has no external runtime dependency and is kept iframe-friendly (self-contained styling and minimal inline script).

### Testing

- Installed dependencies with `npm install` and the command completed successfully.
- Ran the static site build with `npm run build` and the build completed without errors.
- Ran the EJS smoke test with `npm run test:ejs` which executed successfully and reported the installed EJS version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a076497173883318ff9b26af3ee83fc)