### PR TITLE
Fix prompt-to-product webinar form ID and asset slug

### DIFF
--- a/webinars/prompt-to-product/index.html
+++ b/webinars/prompt-to-product/index.html
@@ -5,8 +5,9 @@
      ============================================================ -->
 <script>
 window.RTG_CONFIG = {
-    assetSlug:    'on-demand-webinar-prompt-to-product', // RT Gate asset slug — resolves the form via Mappings
-        storageKey:   'rtg_webinar_prompt_to_product_access_v1',
+    assetSlug:    'webinar-prompt-to-product', // RT Gate asset slug — resolves the form via Mappings
+    mappingId:    6,                           // Active RT Gate mapping ID for this asset
+    storageKey:   'rtg_webinar_prompt_to_product_access_v1',
     badgeText:    'On-Demand Webinar Recording',
     heroTitle:    'From Prompt to Product',
     heroSubtitle: 'Complete the short form below to unlock the webinar recording on demand.',


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Corrected `assetSlug` from `'on-demand-webinar-prompt-to-product'` to `'webinar-prompt-to-product'` to match the RT Gate asset slug
- Added `mappingId: 6` to scope form resolution to the correct mapping (General Form → webinar-prompt-to-product, mapping created 2026-05-15)

## Test plan

- [ ] Visit the prompt-to-product webinar page and verify the form loads correctly
- [ ] Submit the form and confirm the video unlocks
- [ ] Confirm no errors in browser console related to asset slug resolution

https://claude.ai/code/session_01JgfpMwAPUsQ86yPnrmaMjP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgfpMwAPUsQ86yPnrmaMjP)_