### PR TITLE
Use featured image for prompt-to-product form image panel

### DIFF
--- a/webinars/prompt-to-product/index.html
+++ b/webinars/prompt-to-product/index.html
@@ -203,8 +203,8 @@ window.RTG_CONFIG = {
         <div class="rt-gv-container">
             <div id="rtGvContentRow" class="rt-gv-content-row">
             <div class="rt-gv-chart">
-                <p class="rt-gv-chart-label">From Prompt to Product Webinar</p>
-                <img src="https://realtreasury.com/wp-content/uploads/2026/05/prompt-to-product-webinar-cover.png" alt="From Prompt to Product webinar cover" loading="lazy">
+                <p class="rt-gv-chart-label" id="rtGvChartLabel">From Prompt to Product Webinar</p>
+                <img id="rtGvFeaturedImage" src="https://realtreasury.com/wp-content/uploads/2026/05/prompt-to-product-webinar-cover.png" alt="From Prompt to Product webinar cover" loading="lazy">
             </div>
             <div id="rtGvFormCard" class="rt-gv-form-card" role="region" aria-labelledby="rt-gv-form-heading">
                 <h3 id="rt-gv-form-heading" class="rt-gv-form-heading"></h3>
@@ -258,6 +258,33 @@ window.RTG_CONFIG = {
     setText('rtGvBadge',       C.badgeText    || 'Free On-Demand Workshop');
     setText('rtGvSubtitle',    C.heroSubtitle || 'Complete the short form below to get instant access.');
     setText('rtGvFormSubtext', C.formSubtext  || 'Fill out the form below for instant access.');
+
+    function setFeaturedImageFromPage() {
+        var featuredImageEl = document.getElementById('rtGvFeaturedImage');
+        if (!featuredImageEl) return;
+
+        var sourceEl = document.querySelector('.wp-post-image, .post-thumbnail img, .entry-content img, .wp-block-post-featured-image img');
+        if (!sourceEl) sourceEl = document.querySelector('meta[property="og:image"], meta[name="twitter:image"]');
+
+        var imageSrc = '';
+        var imageAlt = '';
+
+        if (sourceEl) {
+            if (sourceEl.tagName === 'META') {
+                imageSrc = sourceEl.getAttribute('content') || '';
+            } else {
+                imageSrc = sourceEl.getAttribute('src') || sourceEl.getAttribute('data-src') || '';
+                imageAlt = sourceEl.getAttribute('alt') || '';
+            }
+        }
+
+        if (imageSrc) {
+            featuredImageEl.src = imageSrc;
+            featuredImageEl.alt = imageAlt || (document.title ? document.title + ' featured image' : featuredImageEl.alt);
+        }
+    }
+
+    setFeaturedImageFromPage();
     setText('rtGvCtaHeading',  C.ctaHeading   || 'Ready to take the next step?');
 
     var heroTitle = document.getElementById('rt-gv-hero-heading');


### PR DESCRIPTION
### Motivation
- Make the image shown next to the Prompt to Product form use the page's featured image when available so the form panel matches the post's visual context.

### Description
- Added stable element IDs to the image panel markup (`rtGvChartLabel`, `rtGvFeaturedImage`) so the image and label can be targeted by script.
- Implemented `setFeaturedImageFromPage()` which looks for common WordPress featured-image selectors and falls back to `og:image`/`twitter:image` meta tags, then applies the discovered `src` and `alt` to the panel image.
- Kept the original hardcoded image URL as a fallback and invoked the helper during page initialization so the image is set immediately.
- Changes are limited to `webinars/prompt-to-product/index.html` and only affect client-side initialization and markup for the form image panel.

### Testing
- Ran `npm install` and the dependency installation completed successfully.
- Ran `npm run build` and the site build completed with pages rendered successfully.
- Ran `npm run test:ejs` and the EJS presence check succeeded (reported installed version).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a2fa1224833185777f7e83e722b2)