### PR TITLE
Add YouTube iframe embed support and swap between HTML5 video and YouTube player

### DIFF
--- a/webinars/prompt-to-product/index.html
+++ b/webinars/prompt-to-product/index.html
@@ -224,6 +224,7 @@ window.RTG_CONFIG = {
                     <video id="rtGvVideo" controls controlsList="nodownload" playsinline preload="metadata" oncontextmenu="return false;">
                         Your browser does not support the video tag.
                     </video>
+                    <iframe id="rtGvYouTube" title="YouTube video player" style="display:none;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
                 </div>
                 <div class="rt-gv-video-cta">
                     <p class="rt-gv-cta-heading" id="rtGvCtaHeading"></p>
@@ -323,6 +324,7 @@ window.RTG_CONFIG = {
     var contentRow    = document.getElementById('rtGvContentRow');
     var videoCard     = document.getElementById('rtGvVideoCard');
     var formContainer = document.getElementById('rtGvFormContainer');
+    var youtubeEl    = document.getElementById('rtGvYouTube');
 
     function parseJsonOrThrow(response) { return response.text().then(function(text) { var json = {}; try { json = text ? JSON.parse(text) : {}; } catch (e) { throw new Error('Invalid JSON (' + response.status + ')'); } if (!response.ok) { throw new Error(json.message || 'Request failed (' + response.status + ')'); } return json; }); }
     function getStoredAccess() { try { var raw = localStorage.getItem(STORAGE_KEY); return raw ? JSON.parse(raw) : null; } catch (e) { return null; } }
@@ -333,11 +335,42 @@ window.RTG_CONFIG = {
     function escHtml(s) { var d = document.createElement('div'); d.appendChild(document.createTextNode(s)); return d.innerHTML; }
     function escAttr(s) { return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 
+    function getYouTubeEmbedUrl(url) {
+        if (!url) return '';
+        try {
+            var parsed = new URL(url, window.location.href);
+            var host = (parsed.hostname || '').toLowerCase();
+            var id = '';
+            if (host.indexOf('youtu.be') !== -1) id = (parsed.pathname || '').replace(/^\//, '').split('/')[0];
+            else if (host.indexOf('youtube.com') !== -1 || host.indexOf('youtube-nocookie.com') !== -1) {
+                id = parsed.searchParams.get('v') || '';
+                if (!id && parsed.pathname.indexOf('/embed/') === 0) id = parsed.pathname.split('/')[2] || '';
+                if (!id && parsed.pathname.indexOf('/shorts/') === 0) id = parsed.pathname.split('/')[2] || '';
+            }
+            id = (id || '').trim();
+            return id ? ('https://www.youtube-nocookie.com/embed/' + encodeURIComponent(id) + '?rel=0') : '';
+        } catch (e) { return ''; }
+    }
+
     /* ---- Video swap ---- */
     function showVideo(videoUrl, animate) {
         var hideTarget = contentRow || formCard;
         if (!hideTarget || !videoCard || !videoEl) return;
-        if (videoUrl) videoEl.src = videoUrl;
+
+        var ytEmbed = getYouTubeEmbedUrl(videoUrl);
+        if (ytEmbed && youtubeEl) {
+            videoEl.pause();
+            videoEl.removeAttribute('src');
+            videoEl.load();
+            videoEl.style.display = 'none';
+            youtubeEl.src = ytEmbed;
+            youtubeEl.style.display = 'block';
+        } else {
+            if (youtubeEl) { youtubeEl.removeAttribute('src'); youtubeEl.style.display = 'none'; }
+            videoEl.style.display = 'block';
+            if (videoUrl) videoEl.src = videoUrl;
+        }
+
         if (animate) {
             hideTarget.style.opacity = '0'; hideTarget.style.transform = 'translateY(-20px)';
             setTimeout(function() { hideTarget.style.display = 'none'; videoCard.style.display = 'block'; void videoCard.offsetHeight; videoCard.style.opacity = '1'; videoCard.style.transform = 'translateY(0)'; videoCard.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 500);


### PR DESCRIPTION
### Motivation
- Enable the webinar page to display YouTube-hosted recordings in addition to native HTML5 video so recordings hosted on YouTube can be embedded and played.
- Prefer the privacy-enhanced YouTube embed domain and ensure only one player is active at a time to avoid dual playback or download exposure.

### Description
- Inserted an iframe element for a YouTube player with `id="rtGvYouTube"` and appropriate `allow` and `referrerpolicy` attributes, initially hidden in the DOM.
- Added `youtubeEl` DOM reference and a new helper `getYouTubeEmbedUrl()` that parses common YouTube URL forms (`youtu.be`, `youtube.com` with `v=`, `/embed/`, `/shorts/`) and returns a `https://www.youtube-nocookie.com/embed/{id}?rel=0` URL.
- Updated `showVideo()` to detect YouTube links and switch between the native `video` element and the YouTube `iframe`, pausing and clearing the native video when switching to the iframe and clearing the iframe `src` when falling back to the native player.
- Ensured element visibility and `src` toggling are handled to prevent simultaneous playback and to maintain the existing animated reveal behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07ce61f0708331bbf1fa18df527753)