### PR TITLE
Fix YouTube embed sizing in gated webinar player

### DIFF
--- a/templates/partials/gated-video.html
+++ b/templates/partials/gated-video.html
@@ -143,7 +143,8 @@
     .rt-gv-video-card { display: none; opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease, transform 0.6s ease; max-width: 100%; margin: 0 auto; text-align: center; }
     .rt-gv-video-welcome { font-size: 1.5rem; font-weight: 700; color: var(--dark-text); margin-bottom: 24px; }
     .rt-gv-video-player { position: relative; width: 100%; padding-bottom: 56.25%; border-radius: 16px; overflow: hidden; box-shadow: 0 12px 48px rgba(114,22,244,0.15); border: 2px solid rgba(199,125,255,0.2); background: var(--black); }
-    .rt-gv-video-player video { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; object-fit: contain; }
+    .rt-gv-video-player video, .rt-gv-video-player iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+    .rt-gv-video-player video { object-fit: contain; }
     .rt-gv-video-player video::-webkit-media-controls-download-button,
     .rt-gv-video-player video::-webkit-media-controls-overflow-menu-list-item:last-child { display: none !important; }
     .rt-gv-video-cta { margin-top: 40px; }

--- a/webinars/prompt-to-product/index.html
+++ b/webinars/prompt-to-product/index.html
@@ -166,7 +166,8 @@ window.RTG_CONFIG = {
     .rt-gv-video-card { display: none; opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease, transform 0.6s ease; max-width: 100%; margin: 0 auto; text-align: center; }
     .rt-gv-video-welcome { font-size: 1.5rem; font-weight: 700; color: var(--dark-text); margin-bottom: 24px; }
     .rt-gv-video-player { position: relative; width: 100%; padding-bottom: 56.25%; border-radius: 16px; overflow: hidden; box-shadow: 0 12px 48px rgba(114,22,244,0.15); border: 2px solid rgba(199,125,255,0.2); background: var(--black); }
-    .rt-gv-video-player video { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; object-fit: contain; }
+    .rt-gv-video-player video, .rt-gv-video-player iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0; }
+    .rt-gv-video-player video { object-fit: contain; }
     .rt-gv-video-player video::-webkit-media-controls-download-button,
     .rt-gv-video-player video::-webkit-media-controls-overflow-menu-list-item:last-child { display: none !important; }
     .rt-gv-video-cta { margin-top: 40px; }


### PR DESCRIPTION
### Motivation
- Embedded YouTube iframes inside the gated webinar player were rendering as a small square in the top-left because the iframe did not receive the same absolute, full-container positioning rules as the native `<video>` element.

### Description
- Add `.rt-gv-video-player iframe` to the positioning CSS so iframes are positioned `absolute` and sized to `width: 100%` / `height: 100%` alongside the existing `video` rules in `templates/partials/gated-video.html` and `webinars/prompt-to-product/index.html`.

### Testing
- Ran `npm run build` and the site built successfully; the updated pages were rendered without errors. 
- Ran `npm run test:ejs` and the EJS version check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d859fa748331b01f6167be8e4ede)