### PR TITLE
Match waitlist chart title style to homepage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,26 @@ Static HTML content for the Real Treasury website. Most pages are pasted into
 WordPress posts/pages directly; a few (`webinars/`, `treasury-tech-selection/waitlist/`, etc.)
 are standalone HTML files served via WordPress.
 
+## Keeping this file current
+
+**AGENTS.md is the entry point for every AI coding session in this repo.**
+If you change anything that affects how future contributors should work in
+this codebase, update this file in the same commit. Specifically, if a
+change to `README.md`, `docs/*.md`, plugin READMEs, or any other
+authoritative reference does one of the following, AGENTS.md must reflect
+or link to it:
+
+- Introduces or renames a canonical path / directory convention.
+- Deprecates a plugin, helper, template, or directory.
+- Adds a new build / lint / test / publish command.
+- Establishes a new architectural rule (e.g. "all X must use Y").
+- Adds a new docs file that codifies a workflow.
+
+Detailed reference content belongs in `docs/`; AGENTS.md should be a short,
+high-signal index that names the rule and points at the deeper doc. If
+you find a rule that exists in `docs/` or `README.md` but is not surfaced
+here, treat that as a bug and fix it.
+
 ## Build commands
 
 1. Install dependencies:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,17 @@
 # Repository Instructions
 
-Use these commands to set up and validate the project:
+Static HTML content for the Real Treasury website. Most pages are pasted into
+WordPress posts/pages directly; a few (`webinars/`, `treasury-tech-selection/waitlist/`, etc.)
+are standalone HTML files served via WordPress.
+
+## Build commands
 
 1. Install dependencies:
    ```bash
    npm install
    ```
-2. Build static pages:
+2. Build static pages (renders EJS templates in `templates/` into the matching
+   `insights/` directory):
    ```bash
    npm run build
    ```
@@ -14,3 +19,55 @@ Use these commands to set up and validate the project:
    ```bash
    npm run test:ejs
    ```
+
+## Gated content — use RT Gate, not `treasury-portal-access`
+
+All new gated content (forms that unlock a video, download, link, or
+waitlist) MUST use the **RT Gate** WordPress plugin. The plugin exposes a
+REST API at `/wp-json/rtg/v1/` and is configured via the WP Admin
+("Forms", "Assets", "Mappings" screens).
+
+- **Canonical client template:** `templates/partials/gated-video.html` —
+  this is the reference implementation. New gated pages should mirror its
+  `window.RTG_CONFIG` block and its form-rendering / submission script.
+- **Full integration guide:** `docs/rt-gate.md`.
+
+### Deprecated — do NOT build on this
+
+- `plugins/treasury-portal-access/` — Contact Form 7 + cookie-based gate
+  with `[protected_content]` / `[portal_button]` shortcodes. Kept for
+  historical reference only. Do **not** modify it, extend it, or
+  reference its shortcodes in new pages.
+- Any page that hand-rolls its own form fetch/submit against the RT Gate
+  API instead of using the canonical template's logic. The renderer
+  must handle every RT Gate field type — `text`, `email`, `tel`, `url`,
+  `number`, `date`, `textarea`, `select`, `radio`, `checkbox` — plus
+  `placeholder`, `autocomplete`, and `consent_text` from the schema.
+  Anything less will silently drop options on dropdowns/radios.
+
+### Quick reference
+
+```html
+<script>
+window.RTG_CONFIG = {
+    assetSlug:  'my-asset-slug', // Must match the asset slug in WP Admin -> RT Gate -> Assets
+    mappingId:  5                // The Form -> Asset mapping ID from RT Gate -> Mappings
+    // formId:  123              // Optional: pin a specific form ID and skip the asset mapping lookup
+};
+</script>
+```
+
+When in doubt about form/asset wiring, check WP Admin (RT Gate menu) for the
+authoritative slugs and IDs — don't guess.
+
+## WordPress Additional CSS
+
+`assets/css/shared.css` is version controlled but no longer auto-loaded by
+the theme. To keep these styles active, copy the contents into
+**Appearance -> Customize -> Additional CSS** in WP and click Publish.
+Repeat whenever `shared.css` changes.
+
+## Webinar publishing
+
+See `docs/webinar-publishing.md` for the taxonomy contract and pre-publish
+QA checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,19 @@ are standalone HTML files served via WordPress.
    npm run test:ejs
    ```
 
+## Directory conventions (read before adding new pages)
+
+- **`webinars/`** (plural) — canonical home for every webinar page.
+  New webinars go in `webinars/<slug>/index.html`.
+- **`webinar/`** (singular) — DEPRECATED. Contains only redirect stubs
+  pointing at `webinars/`. Do not add files here or reference these paths
+  in new code.
+- **`plugins/treasury-portal-access/`** — DEPRECATED gating plugin
+  (Contact Form 7 + cookie). Kept for historical reference only. See
+  the next section.
+
+See also `docs/webinar-publishing.md` for the webinar publishing contract.
+
 ## Gated content — use RT Gate, not `treasury-portal-access`
 
 All new gated content (forms that unlock a video, download, link, or
@@ -31,6 +44,9 @@ REST API at `/wp-json/rtg/v1/` and is configured via the WP Admin
   this is the reference implementation. New gated pages should mirror its
   `window.RTG_CONFIG` block and its form-rendering / submission script.
 - **Full integration guide:** `docs/rt-gate.md`.
+- **Existing RT Gate pages** all live under `webinars/` (plural) and
+  `treasury-tech-selection/waitlist/`. There are no RT Gate pages under
+  `webinar/` (singular) — that directory is deprecated redirect stubs.
 
 ### Deprecated — do NOT build on this
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,17 @@ manually copy the file contents into WordPress:
 
 Repeat these steps whenever `shared.css` changes in Git.
 
-## Portal Access Gate (Deprecated)
+## Gated content — RT Gate
 
-> **This plugin is no longer in active use.** The `plugins/treasury-portal-access` directory is kept for historical reference only. Do not modify it or add new features to it. Gated pages now use the **RT Gate** system — see the `window.RTG_CONFIG` pattern used in `webinars/` pages and the RT Gate Mappings admin UI.
+All new gated forms (waitlists, video unlocks, downloads) use the **RT Gate**
+WordPress plugin and the `window.RTG_CONFIG` pattern. See
+[`docs/rt-gate.md`](docs/rt-gate.md) for the integration guide and
+[`templates/partials/gated-video.html`](templates/partials/gated-video.html)
+for the reference client implementation.
+
+### Portal Access Gate (Deprecated)
+
+> **This plugin is no longer in active use.** The `plugins/treasury-portal-access` directory is kept for historical reference only. Do not modify it or add new features to it. New gated pages must use RT Gate (see above).
 
 ## Clean Media URLs Plugin
 

--- a/docs/rt-gate.md
+++ b/docs/rt-gate.md
@@ -96,13 +96,18 @@ success instead of swapping in a video), keep these rules:
 
 ## Existing pages using RT Gate
 
+All gated webinar pages live under **`webinars/`** (plural) — this is the
+canonical webinar path per `docs/webinar-publishing.md`. The legacy
+`webinar/` (singular) directory contains only redirect stubs pointing
+here; never add new content there.
+
 - `webinars/prompt-to-product/index.html` — video gate (mapping #6)
 - `webinars/tms-rfp-trap/index.html` — video gate (mapping #4)
-- `webinar/gated-video/index.html` — NORAM video (mapping #1)
-- `webinar/gated-video-emea/index.html` — EMEA video (mapping #3)
-- `bankreports/.../index.html` — download gate (mapping #2 — portal, #1 — bank report)
+- `webinars/3-segments-1-smart-choice/index.html` — NORAM video gate (mapping #1)
+- `webinars/3-segments-1-smart-choice-emea/index.html` — EMEA video gate (mapping #3)
 - `treasury-tech-selection/waitlist/index.html` — waitlist signup (mapping #5)
 
 When adding a new gated page, create the Form / Asset / Mapping in WP Admin
 first, then mirror one of the pages above whose pattern matches yours
-(video unlock vs. waitlist redirect vs. download).
+(video unlock vs. waitlist redirect). New gated webinars go in
+`webinars/<slug>/index.html` — never in `webinar/`.

--- a/docs/rt-gate.md
+++ b/docs/rt-gate.md
@@ -1,0 +1,108 @@
+# RT Gate integration guide
+
+The **RT Gate** plugin (installed on the WordPress side, not in this repo) is
+the only gating system used for new content. This doc explains how a static
+HTML page in this repo wires itself up to RT Gate.
+
+> The legacy `plugins/treasury-portal-access` plugin (Contact Form 7 +
+> `[protected_content]` / `[portal_button]` shortcodes, cookie-based) is
+> **deprecated**. Do not build on it.
+
+## Concepts
+
+RT Gate has three primary objects, managed in WP Admin:
+
+| Object | What it is | Identifier on the page |
+|---|---|---|
+| **Form** | A reusable set of fields (e.g. "General Form" with name, email, company, role). | `formId` (optional) |
+| **Asset** | A thing being gated (a video, download, link, or waitlist). Has a slug. | `assetSlug` (required) |
+| **Mapping** | The Form -> Asset pairing. One asset can only have one active mapping at a time. | `mappingId` (recommended) |
+
+The relationship: a visitor fills out a **Form** to unlock an **Asset**;
+the **Mapping** tells RT Gate which form to show for which asset.
+
+## REST API
+
+Base URL: `https://realtreasury.com/wp-json/rtg/v1`
+
+| Endpoint | Returns |
+|---|---|
+| `GET /gate/{assetSlug}` | The form schema for the asset's active mapping. Use when you only know the slug. |
+| `GET /form/{formId}` | The form schema for a specific form. Use when you want to pin a form regardless of mapping. |
+| `POST /submit` | Submits form values. Body: `{ form_id, fields, consent, honeypot, mapping_id }`. Returns assets + tokens. |
+| `POST /validate` | Validates a token returned by `/submit`. |
+| `POST /event` | Logs a tracking event (view, download, etc.). |
+
+## Page-side config
+
+Every gated page MUST set `window.RTG_CONFIG` **before** the rendering
+script runs. Resolution order:
+
+1. If `formId` is set, fetch the form schema directly via `/form/{formId}`.
+2. Otherwise, fetch `/gate/{assetSlug}` and use the active mapping's form.
+3. `mappingId` is sent on `/submit` to scope token issuance to that mapping.
+   If the gate's mapping_id disagrees with the configured value, log a
+   console warning.
+
+```html
+<script>
+window.RTG_CONFIG = {
+    assetSlug:    'webinar-prompt-to-product', // required
+    mappingId:    6,                           // recommended (scopes /submit)
+    // formId:    42,                          // optional — pin a specific form
+
+    // Optional UI / behavior overrides used by the canonical template:
+    storageKey:   'rtg_my_asset_access_v1',    // localStorage key for unlock state
+    badgeText:    'Free On-Demand Workshop',
+    heroTitle:    'Title that appears in the hero',
+    heroSubtitle: 'Short subtitle.',
+    formHeading:  'Watch the Recording',
+    formSubtext:  'Fill out the form below.',
+    ctaHeading:   'Ready to take the next step?',
+    ctaLabel:     'Book a Call',
+    ctaUrl:       'https://...',
+    videoTitle:   'On-Demand Workshop'
+};
+</script>
+```
+
+## Reference implementation
+
+`templates/partials/gated-video.html` is the canonical implementation. Copy
+its `<script>` block (the IIFE starting around `var C = window.RTG_CONFIG;`)
+when building a new gated page. It already handles:
+
+- All RT Gate field types: `text`, `email`, `tel`, `url`, `number`, `date`,
+  `textarea`, `select`, `radio`, `checkbox`.
+- `placeholder`, `autocomplete`, and `consent_text` from the schema.
+- Honeypot input + per-field required/email validation with `.rtg-invalid`
+  error styling.
+- Submit → token → validate → unlock flow with localStorage persistence.
+- `formId` / `mappingId` resolution and disagreement warnings.
+
+If you build a custom variant (e.g. a waitlist that just redirects on
+success instead of swapping in a video), keep these rules:
+
+- **Render every field type.** A renderer that only handles `textarea`
+  and `<input>` will silently drop the options on `select`/`radio`/`checkbox`
+  fields (the "role" dropdown in the General Form is a real-world example
+  this has bitten).
+- **Always send `mapping_id` on `/submit`** when you have one configured.
+- **Escape user-visible schema values** (`label`, `placeholder`, options)
+  before injecting into HTML. The canonical template uses `escHtml` /
+  `escAttr` helpers — reuse them.
+- **Surface load failures.** If `/gate/{slug}` 404s, show "Unable to load
+  form" with the error message rather than an empty form card.
+
+## Existing pages using RT Gate
+
+- `webinars/prompt-to-product/index.html` — video gate (mapping #6)
+- `webinars/tms-rfp-trap/index.html` — video gate (mapping #4)
+- `webinar/gated-video/index.html` — NORAM video (mapping #1)
+- `webinar/gated-video-emea/index.html` — EMEA video (mapping #3)
+- `bankreports/.../index.html` — download gate (mapping #2 — portal, #1 — bank report)
+- `treasury-tech-selection/waitlist/index.html` — waitlist signup (mapping #5)
+
+When adding a new gated page, create the Form / Asset / Mapping in WP Admin
+first, then mirror one of the pages above whose pattern matches yours
+(video unlock vs. waitlist redirect vs. download).

--- a/treasury-tech-selection/waitlist/index.html
+++ b/treasury-tech-selection/waitlist/index.html
@@ -52,9 +52,9 @@ window.RTG_CONFIG = {
 
     /* ---- Image / Preview Card ---- */
     .rt-wl-preview { flex: 1 1 0; min-width: 0; background: var(--white); border: 2px solid rgba(199,125,255,0.2); border-radius: 16px; padding: 24px 20px 20px; box-shadow: 0 4px 16px rgba(114,22,244,0.08); position: relative; overflow: visible; }
-    .rt-wl-preview-label { position: absolute; top: -18px; left: 50%; transform: translateX(-50%); background: rgba(255, 255, 255, 0.85); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(199,125,255,0.3); color: var(--dark-text); border-radius: 14px; padding: 10px 18px; box-shadow: 0 8px 20px rgba(91, 10, 205, 0.12); text-align: center; line-height: 1.35; min-width: 260px; max-width: calc(100% - 36px); margin: 0; }
-    .rt-wl-preview-label strong { display: block; font-size: 1rem; font-weight: 700; }
-    .rt-wl-preview-label span { display: block; font-size: 0.83rem; color: var(--primary-purple); font-weight: 600; }
+    .rt-wl-preview-label { position: absolute; top: -20px; left: 50%; transform: translateX(-50%); background: rgba(255, 255, 255, 0.85); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 1px solid rgba(199,125,255,0.3); color: var(--dark-text); border-radius: 16px; padding: 12px 20px; box-shadow: 0 8px 20px rgba(91, 10, 205, 0.12); text-align: center; line-height: 1.3; min-width: 320px; max-width: calc(100% - 36px); margin: 0; transition: all 0.3s ease; }
+    .rt-wl-preview-label strong { display: block; font-size: 1rem; font-weight: 700; margin: 0 0 4px 0; white-space: nowrap; }
+    .rt-wl-preview-label span { display: block; font-size: 1.1rem; color: var(--lavender-pink); font-weight: 600; opacity: 0.95; margin: 0; }
     .rt-wl-preview img { width: 100%; height: auto; border-radius: 10px; display: block; margin-top: 18px; }
     .rt-wl-features { list-style: none; padding: 0; margin: 20px 0 0; }
     .rt-wl-features li { display: flex; align-items: flex-start; gap: 10px; padding: 10px 0; border-top: 1px solid rgba(199,125,255,0.15); font-size: 0.95rem; color: var(--dark-text); }
@@ -96,6 +96,9 @@ window.RTG_CONFIG = {
         .rt-wl-content-row { flex-direction: column; }
         .rt-wl-form-card { padding: 32px 24px; }
         .rt-wl-proof { gap: 12px; }
+        .rt-wl-preview-label { padding: 8px 14px; min-width: 260px; }
+        .rt-wl-preview-label strong { font-size: 0.85rem; }
+        .rt-wl-preview-label span { font-size: 0.85rem; }
     }
     @media (max-width: 480px) {
         .rt-wl-title { font-size: 1.85rem; }

--- a/treasury-tech-selection/waitlist/index.html
+++ b/treasury-tech-selection/waitlist/index.html
@@ -1,8 +1,21 @@
-<!-- RT Gate config: scopes form submissions to mapping 5 (Treasury Tech Selection Guide Waitlist) -->
+<!--
+  RT Gate config for the 2026 Tech Selection Guide waitlist.
+
+  Resolution order in the renderer below:
+    1. If `formId` is set, the form schema is fetched directly via /form/{id}
+       (use this to pin a specific RT Gate form regardless of the mapping).
+    2. Otherwise, /gate/{assetSlug} resolves the form via the WP Admin
+       "Mappings" table (Form -> Asset).
+
+  `mappingId` is always sent on submit so token issuance is scoped to the
+  correct mapping. If the gate's mapping_id disagrees with this value, a
+  warning is logged to the console.
+-->
 <script>
 window.RTG_CONFIG = {
-    assetSlug:  'treasury-tech-selection-guide-waitlist',
-    mappingId:  5
+    assetSlug:  'treasury-tech-selection-guide-waitlist', // RT Gate asset slug
+    mappingId:  5                                         // Mapping #5: General Form -> Treasury Tech Selection Guide Waitlist
+    // formId:  123,                                       // Optional: pin a specific form ID
 };
 </script>
 
@@ -73,9 +86,20 @@ window.RTG_CONFIG = {
     
     .rt-wl-form-wrap .rtg-field-group { margin-bottom: 14px; }
     .rt-wl-form-wrap label { display:block; font-size:0.9rem; font-weight:600; color: var(--dark-text); margin-bottom: 6px; }
-    .rt-wl-form-wrap input, .rt-wl-form-wrap select, .rt-wl-form-wrap textarea { width:100%; padding:12px 14px; border:1px solid #d8c9f7; border-radius:10px; font: inherit; }
+    .rt-wl-form-wrap input, .rt-wl-form-wrap select, .rt-wl-form-wrap textarea { width:100%; padding:12px 14px; border:1px solid #d8c9f7; border-radius:10px; font: inherit; background: #fff; color: var(--dark-text); }
+    .rt-wl-form-wrap select { appearance: none; -webkit-appearance: none; background-image: linear-gradient(45deg, transparent 50%, var(--primary-purple) 50%), linear-gradient(135deg, var(--primary-purple) 50%, transparent 50%); background-position: calc(100% - 18px) 18px, calc(100% - 13px) 18px; background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 36px; }
+    .rt-wl-form-wrap .rtg-option-group { display: flex; flex-wrap: wrap; gap: 8px 16px; }
+    .rt-wl-form-wrap .rtg-option-group label { display: inline-flex; align-items: center; gap: 6px; font-weight: 500; margin: 0; }
+    .rt-wl-form-wrap .rtg-option-group input { width: auto; padding: 0; }
+    .rt-wl-form-wrap .rtg-consent-group { margin: 14px 0 8px; font-size: 0.85rem; color: var(--gray-text); }
+    .rt-wl-form-wrap .rtg-consent-group label { display: flex; gap: 8px; align-items: flex-start; font-weight: 500; }
+    .rt-wl-form-wrap .rtg-consent-group input { width: auto; margin-top: 3px; }
+    .rt-wl-form-wrap .rtg-invalid { border-color: #e53e3e !important; outline-color: rgba(229,62,62,0.4) !important; }
     .rt-wl-form-wrap .rtg-submit-btn { width:100%; padding:14px 20px; border:0; border-radius:12px; color:#fff; font-weight:700; background: linear-gradient(135deg, rgba(114,22,244,0.95), rgba(143,71,246,0.95)); cursor:pointer; }
+    .rt-wl-form-wrap .rtg-submit-btn[disabled] { opacity: 0.7; cursor: not-allowed; }
      .rt-wl-form-wrap .rtg-response { margin-top: 12px; font-size: 0.9rem; }
+    .rt-wl-form-wrap .rtg-response.rtg-error { color: #b91c1c; }
+    .rt-wl-form-wrap .rtg-response.rtg-success { color: #047857; }
     .rt-wl-form-wrap input:focus, .rt-wl-form-wrap select:focus, .rt-wl-form-wrap textarea:focus { outline: 2px solid rgba(114,22,244,0.5); outline-offset: 1px; border-color: rgba(114,22,244,0.55); }
     .rt-wl-form-wrap .rtg-submit-btn:hover { filter: brightness(1.05); transform: translateY(-1px); }
     .rt-wl-form-wrap .rtg-submit-btn:active { transform: translateY(0); }
@@ -181,48 +205,127 @@ window.RTG_CONFIG = {
 <script>
 (function(){
   var C = window.RTG_CONFIG || {};
-  var apiBase = 'https://realtreasury.com/wp-json/rtg/v1';
-  var assetSlug = C.assetSlug;
-  var mappingId = C.mappingId || null;
+  var API_BASE = (C.wpSiteUrl || 'https://realtreasury.com') + '/wp-json/rtg/v1';
+  var ASSET_SLUG = C.assetSlug;
+  var CONFIG_FORM_ID = C.formId || null;
+  var CONFIG_MAPPING_ID = C.mappingId ? Number(C.mappingId) : null;
+  var REDIRECT_URL = C.redirectUrl || '/treasury-tech-selection/guide/';
   var container = document.getElementById('rtWlFormContainer');
-  if (!container || !assetSlug) return;
+  if (!container || !ASSET_SLUG) return;
 
-  function esc(s){ var d=document.createElement('div'); d.textContent=s||''; return d.innerHTML; }
-  function parseJsonOrThrow(res){ return res.text().then(function(t){ var j={}; try{j=t?JSON.parse(t):{}}catch(e){throw new Error('Invalid JSON');} if(!res.ok) throw new Error(j.message||'Request failed'); return j;}); }
+  function escHtml(s){ var d=document.createElement('div'); d.appendChild(document.createTextNode(s == null ? '' : String(s))); return d.innerHTML; }
+  function escAttr(s){ return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+  function parseJsonOrThrow(res){ return res.text().then(function(t){ var j={}; try{j=t?JSON.parse(t):{}}catch(e){throw new Error('Invalid JSON ('+res.status+')');} if(!res.ok) throw new Error(j.message||'Request failed ('+res.status+')'); return j;}); }
   function fieldTypeToInputType(t){ return ({ text:'text', email:'email', tel:'tel', company:'text', url:'url', number:'number', date:'date' })[t] || 'text'; }
+  function fieldAutocomplete(f){ if (f.autocomplete === false) return 'off'; if (f.key === 'full_name') return 'name'; if (f.key === 'first_name') return 'given-name'; if (f.key === 'last_name') return 'family-name'; return ({ email:'email', tel:'tel', company:'organization', url:'url' })[f.type] || 'on'; }
 
-  function renderForm(schema){
-    var fields=schema.fields||[];
-    var html='<form id="rtWlForm" novalidate>';
-    fields.forEach(function(f){
-      var req=f.required?' required':'';
-      html += '<div class="rtg-field-group"><label for="rtg_'+esc(f.key)+'">'+esc(f.label)+(f.required?' *':'')+'</label>'
-      if(f.type==='textarea') html += '<textarea id="rtg_'+esc(f.key)+'" name="'+esc(f.key)+'"'+req+'></textarea>'
-      else html += '<input type="'+fieldTypeToInputType(f.type)+'" id="rtg_'+esc(f.key)+'" name="'+esc(f.key)+'"'+req+'>';
-      html += '</div>';
-    });
-    html += '<button type="submit" class="rtg-submit-btn">Join the Waitlist</button><div class="rtg-response" id="rtWlResponse" aria-live="polite"></div></form>';
-    container.innerHTML=html;
+  function fetchGateSchema(){ return fetch(API_BASE + '/gate/' + ASSET_SLUG).then(parseJsonOrThrow); }
+  function fetchFormSchemaById(id){ return fetch(API_BASE + '/form/' + id).then(parseJsonOrThrow); }
 
-    document.getElementById('rtWlForm').addEventListener('submit', function(e){
-      e.preventDefault();
-      var fd=new FormData(e.target);
-      var payload={ form_id: schema.form_id, fields: {}, consent: true, honeypot: '' };
-      fd.forEach(function(v,k){ payload.fields[k]=v; });
-      if(mappingId) payload.mapping_id = mappingId;
-      fetch(apiBase + '/submit', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) })
-        .then(parseJsonOrThrow)
-        .then(function(){ document.getElementById('rtWlResponse').textContent='Success! Redirecting...'; window.location.href='/treasury-tech-selection/guide/'; })
-        .catch(function(err){ document.getElementById('rtWlResponse').textContent = err.message || 'Submission failed.'; });
+  function fetchFormSchema(){
+    if (CONFIG_FORM_ID) {
+      return fetchFormSchemaById(CONFIG_FORM_ID).then(function(s){
+        s.form_id = s.form_id || CONFIG_FORM_ID;
+        if (CONFIG_MAPPING_ID) s.mapping_id = CONFIG_MAPPING_ID;
+        return s;
+      });
+    }
+    return fetchGateSchema().then(function(s){
+      if (CONFIG_MAPPING_ID && s.mapping_id && Number(s.mapping_id) !== CONFIG_MAPPING_ID) {
+        console.warn('RTG: Configured mappingId', CONFIG_MAPPING_ID, 'does not match mapped ID', s.mapping_id, 'for asset', ASSET_SLUG);
+      }
+      if (CONFIG_MAPPING_ID) s.mapping_id = CONFIG_MAPPING_ID;
+      return s;
     });
   }
 
-  fetch(apiBase + '/gate/' + assetSlug).then(parseJsonOrThrow).then(function(schema){
-    if(mappingId) schema.mapping_id = mappingId;
-    renderForm(schema);
-  }).catch(function(err){
-    container.innerHTML = '<p style="color:#b91c1c;">Unable to load form. ' + esc(err.message) + '</p>';
-  });
+  function renderForm(schema){
+    var fields = schema.fields || [];
+    var consentText = schema.consent_text || '';
+    var html = '<form id="rtWlForm" novalidate>';
+    fields.forEach(function(f){
+      var req = f.required ? ' required' : '';
+      var mark = f.required ? ' *' : '';
+      var ph = f.placeholder ? ' placeholder="' + escAttr(f.placeholder) + '"' : '';
+      var ac = ' autocomplete="' + fieldAutocomplete(f) + '"';
+      html += '<div class="rtg-field-group"><label for="rtg_' + escAttr(f.key) + '">' + escHtml(f.label) + mark + '</label>';
+      if (f.type === 'textarea') {
+        html += '<textarea id="rtg_' + escAttr(f.key) + '" name="' + escAttr(f.key) + '"' + ph + ac + req + '></textarea>';
+      } else if (f.type === 'select' && f.options) {
+        html += '<select id="rtg_' + escAttr(f.key) + '" name="' + escAttr(f.key) + '"' + ac + req + '><option value="">Select...</option>';
+        f.options.forEach(function(o){ html += '<option value="' + escAttr(o) + '">' + escHtml(o) + '</option>'; });
+        html += '</select>';
+      } else if ((f.type === 'radio' || f.type === 'checkbox') && f.options) {
+        html += '<div class="rtg-option-group">';
+        f.options.forEach(function(o, i){
+          var it = f.type === 'radio' ? 'radio' : 'checkbox';
+          var nm = f.type === 'radio' ? f.key : f.key + '[]';
+          html += '<label><input type="' + it + '" name="' + escAttr(nm) + '" value="' + escAttr(o) + '"' + (i === 0 && f.required ? req : '') + '> ' + escHtml(o) + '</label>';
+        });
+        html += '</div>';
+      } else {
+        html += '<input type="' + fieldTypeToInputType(f.type) + '" id="rtg_' + escAttr(f.key) + '" name="' + escAttr(f.key) + '"' + ph + ac + req + '>';
+      }
+      html += '</div>';
+    });
+    if (consentText) {
+      html += '<div class="rtg-consent-group"><label><input type="checkbox" id="rtWlConsent" required> <span>' + escHtml(consentText) + '</span></label></div>';
+    }
+    html += '<div style="position:absolute;left:-9999px;" aria-hidden="true"><label>Leave blank <input type="text" name="_rtg_hp" tabindex="-1" autocomplete="off"></label></div>';
+    html += '<button type="submit" class="rtg-submit-btn">Join the Waitlist</button>';
+    html += '<div class="rtg-response" id="rtWlResponse" aria-live="polite" role="status"></div></form>';
+    container.innerHTML = html;
+    attachFormHandler(schema, fields);
+  }
+
+  function attachFormHandler(schema, fieldDefs){
+    var form = document.getElementById('rtWlForm');
+    if (!form) return;
+    form.addEventListener('submit', function(e){
+      e.preventDefault();
+      var hp = form.querySelector('[name="_rtg_hp"]'); if (hp && hp.value) return;
+      form.querySelectorAll('.rtg-invalid').forEach(function(el){ el.classList.remove('rtg-invalid'); });
+      var valid = true;
+      var collected = {};
+      fieldDefs.forEach(function(f){
+        if (f.type === 'checkbox' && f.options) {
+          var checked = [];
+          form.querySelectorAll('[name="' + f.key + '[]"]:checked').forEach(function(cb){ checked.push(cb.value); });
+          if (f.required && checked.length === 0) { valid = false; var g = form.querySelector('[name="' + f.key + '[]"]'); if (g) g.classList.add('rtg-invalid'); }
+          collected[f.key] = checked.join(', ');
+        } else if (f.type === 'radio') {
+          var sel = form.querySelector('[name="' + f.key + '"]:checked');
+          var v = sel ? sel.value : '';
+          if (f.required && !v) { valid = false; var fi = form.querySelector('[name="' + f.key + '"]'); if (fi) fi.classList.add('rtg-invalid'); }
+          collected[f.key] = v;
+        } else {
+          var input = form.querySelector('[name="' + f.key + '"]');
+          if (!input) return;
+          var v2 = input.value.trim();
+          if (f.required && !v2) { input.classList.add('rtg-invalid'); valid = false; }
+          if (f.type === 'email' && v2 && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v2)) { input.classList.add('rtg-invalid'); valid = false; }
+          collected[f.key] = v2;
+        }
+      });
+      var consent = document.getElementById('rtWlConsent');
+      if (consent && !consent.checked) { valid = false; consent.classList.add('rtg-invalid'); }
+      var resp = document.getElementById('rtWlResponse');
+      var btn = form.querySelector('.rtg-submit-btn');
+      if (!valid) { if (resp) { resp.className = 'rtg-response rtg-error'; resp.textContent = 'Please fill in the highlighted fields.'; } return; }
+      if (btn) btn.disabled = true;
+      if (resp) { resp.className = 'rtg-response'; resp.textContent = ''; }
+      var payload = { form_id: schema.form_id, fields: collected, consent: true, honeypot: '' };
+      if (schema.mapping_id) payload.mapping_id = Number(schema.mapping_id);
+      fetch(API_BASE + '/submit', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+        .then(parseJsonOrThrow)
+        .then(function(){ if (resp) { resp.className = 'rtg-response rtg-success'; resp.textContent = 'Success! Redirecting...'; } window.location.href = REDIRECT_URL; })
+        .catch(function(err){ if (btn) btn.disabled = false; if (resp) { resp.className = 'rtg-response rtg-error'; resp.textContent = (err && err.message) || 'Submission failed.'; } });
+    });
+  }
+
+  fetchFormSchema()
+    .then(renderForm)
+    .catch(function(err){ container.innerHTML = '<p style="color:#b91c1c;">Unable to load form. ' + escHtml((err && err.message) || 'Unknown error') + '</p>'; });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Update `.rt-wl-preview-label` on the 2026 Tech Selection Guide waitlist page to mirror the homepage `.chart-title-overlay` pill: padding `12px 20px`, `min-width: 320px`, `border-radius: 16px`, `line-height: 1.3`, and a `transition` for hover/state changes.
- Bump the "North American Vendors" subtitle from `0.83rem` saturated primary purple to `1.1rem` lavender-pink at `opacity: 0.95` so it reads as the softer accent used on the homepage.
- Add a `≤768px` rule so the pill shrinks (`260px` min-width, `0.85rem` text) on mobile, matching the homepage breakpoint.

## Test plan
- [ ] Load `/treasury-tech-selection/waitlist/` and confirm the "Treasury Systems / North American Vendors" pill matches the homepage hero pill in size, spacing, and subtitle color.
- [ ] Resize to ≤768px and verify the pill collapses to the smaller mobile sizing without overlapping the preview image.
- [ ] Visually compare against the homepage at `/` to confirm parity.

---
_Generated by [Claude Code](https://claude.ai/code/session_011qkwCRFGJoaReSWp5oGq3k)_