### PR TITLE
Fix waitlist confirmation page styling in iframe

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -21,19 +21,26 @@
     }
 
     * { box-sizing: border-box; }
-    html, body { min-height: 100%; }
+
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
 
     body {
-      margin: 0;
+      min-height: 100vh;
       font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
       color: var(--text);
       background:
         radial-gradient(900px 520px at 90% -12%, rgba(143, 71, 246, 0.28), transparent 60%),
         radial-gradient(700px 400px at 8% 110%, rgba(199, 125, 255, 0.22), transparent 64%),
         linear-gradient(180deg, #0d1632 0%, var(--slate) 45%, var(--midnight) 100%);
-      display: grid;
-      place-items: center;
-      padding: clamp(1rem, 2vw, 1.5rem);
+      background-attachment: fixed;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 2vw, 1.5rem);
+      overflow-x: hidden;
     }
 
     .card {


### PR DESCRIPTION
## Summary
- Switch body centering from `display: grid; place-items: center` to flex with explicit `min-height: 100vh` so the dark purple gradient reliably paints the full iframe viewport on `/2026-treasury-tech-guide-waitlist/`.
- Add `background-attachment: fixed` and `overflow-x: hidden`, and pull the page padding into `body` so the card has consistent breathing room top/bottom inside the 1200px iframe.
- No markup or copy changes — only layout/background CSS on `html`/`body`. The card itself, the query-param script (`?guide=`, `?year=`), and CTAs are untouched.

## Why
The post-submit redirect at https://realtreasury.com/2026-treasury-tech-guide-waitlist/ embeds this file via a `<iframe scrolling="no" height="1200">`. The previous rules relied on `html, body { min-height: 100% }` plus grid centering, which left a white area visible around the card inside the iframe and made the page look off-brand.

## Test plan
- [ ] Open `https://realtreasury.github.io/rt-wordpress-content/treasury-tech-selection/guide/index.html` directly after Pages rebuilds — confirm the dark gradient covers the full viewport and only the confirmation card renders (no header, no nav).
- [ ] Visit `https://realtreasury.com/2026-treasury-tech-guide-waitlist/` — confirm the iframe shows the card on a dark background end-to-end with no white gap.
- [ ] Append `?guide=Custom%20Name&year=2026` — confirm the H1 and pill update.
- [ ] Resize to <560px width — confirm the two CTAs stack full-width.
- [ ] If a duplicate REAL TREASURY header still appears *inside* the iframe area after this lands, the cause is the iframe `src` in the WP Custom HTML block (pointing at a theme-wrapped URL rather than GitHub Pages) — fix that separately in WP Admin.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxEJ76HhMBzewvuw4ohHEo)_