### PR TITLE
Auto-size waitlist + confirmation iframes, full-bleed dark gradient

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -202,6 +202,29 @@
   </main>
 
   <script>
+  /* iFrame auto-resize — posts content height to the parent. Pairs with
+     assets/js/iframe-resizer.js on the WordPress side. No-op standalone. */
+  (function () {
+    var id = (document.body && document.body.dataset && document.body.dataset.iframeId) || window.location.pathname;
+    if (window.parent === window) return;
+    function postHeight() {
+      var h = (document.documentElement && document.documentElement.scrollHeight) || (document.body && document.body.scrollHeight) || 0;
+      if (window.parent && typeof window.parent.postMessage === 'function') {
+        window.parent.postMessage({ type: 'setHeight', height: h, id: id }, '*');
+      }
+    }
+    var frameId;
+    function schedule() { if (frameId) cancelAnimationFrame(frameId); frameId = requestAnimationFrame(postHeight); }
+    window.addEventListener('load', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true });
+    if (typeof MutationObserver !== 'undefined' && document.body) {
+      new MutationObserver(schedule).observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });
+    }
+    schedule();
+  })();
+  </script>
+
+  <script>
     (function () {
       var params = new URLSearchParams(window.location.search || '');
       var rawGuide = params.get('guide');

--- a/treasury-tech-selection/waitlist/index.html
+++ b/treasury-tech-selection/waitlist/index.html
@@ -30,6 +30,18 @@ window.RTG_CONFIG = {
   <title>2026 Real Treasury Tech Selection Guide | Join the Waitlist</title>
   <meta name="description" content="Join the waitlist for the 2026 Real Treasury Tech Selection Guide and get notified as soon as it launches." />
   <style>
+    /* Full-bleed dark gradient so the embed looks edge-to-edge whether
+       opened standalone or hosted inside an auto-sizing iframe. */
+    html, body { margin: 0; padding: 0; }
+    body {
+        background:
+          radial-gradient(900px 520px at 90% -12%, rgba(143, 71, 246, 0.28), transparent 60%),
+          radial-gradient(700px 400px at 8% 110%, rgba(199, 125, 255, 0.22), transparent 64%),
+          linear-gradient(180deg, #0d1632 0%, #0e152b 45%, #05070f 100%);
+        background-attachment: fixed;
+        min-height: 100vh;
+    }
+
     .rt-waitlist {
         --primary-purple: #7216f4;
         --secondary-purple: #8f47f6;
@@ -54,13 +66,12 @@ window.RTG_CONFIG = {
     /* ---- Layout ---- */
     .rt-wl-container { max-width: 1200px; margin: 0 auto; padding: 0 24px; }
 
-    /* ---- Hero ---- */
-    .rt-wl-hero { background: var(--gradient-light); padding: 60px 0 48px; text-align: center; position: relative; overflow: hidden; }
-    .rt-wl-hero::before { content: ''; position: absolute; top: 0; left: 0; right: 0; bottom: 0; background: radial-gradient(circle at 30% 20%, rgba(114,22,244,0.08) 0%, transparent 50%), radial-gradient(circle at 80% 80%, rgba(143,71,246,0.06) 0%, transparent 50%); pointer-events: none; }
+    /* ---- Hero (transparent over dark body gradient) ---- */
+    .rt-wl-hero { background: transparent; padding: 60px 0 48px; text-align: center; position: relative; overflow: hidden; }
     .rt-wl-hero .rt-wl-container { position: relative; z-index: 2; }
-    .rt-wl-badge { display: inline-block; background: rgba(199,125,255,0.1); border: 1px solid rgba(199,125,255,0.25); border-radius: 20px; padding: 8px 20px; font-size: 0.875rem; font-weight: 600; color: var(--primary-purple); margin-bottom: 24px; }
-    .rt-wl-title { font-size: 3rem; font-weight: 800; line-height: 1.15; margin-bottom: 20px; background: linear-gradient(135deg, var(--dark-text) 0%, var(--primary-purple) 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; padding-bottom: 0.08em; }
-    .rt-wl-subtitle { font-size: 1.15rem; color: var(--gray-text); line-height: 1.6; max-width: 720px; margin: 0 auto; font-weight: 400; }
+    .rt-wl-badge { display: inline-block; background: rgba(199,125,255,0.18); border: 1px solid rgba(199,125,255,0.4); border-radius: 20px; padding: 8px 20px; font-size: 0.875rem; font-weight: 600; color: #ede9fe; margin-bottom: 24px; }
+    .rt-wl-title { font-size: 3rem; font-weight: 800; line-height: 1.15; margin-bottom: 20px; background: linear-gradient(90deg, #f8f9ff 0%, #dfc8ff 65%, #b89dff 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; padding-bottom: 0.08em; }
+    .rt-wl-subtitle { font-size: 1.15rem; color: #b6bfd9; line-height: 1.6; max-width: 720px; margin: 0 auto; font-weight: 400; }
 
     /* ---- Side-by-side row ---- */
     .rt-wl-content-section { padding: 48px 0; }
@@ -337,6 +348,30 @@ window.RTG_CONFIG = {
   fetchFormSchema()
     .then(renderForm)
     .catch(function(err){ container.innerHTML = '<p style="color:#b91c1c;">Unable to load form. ' + escHtml((err && err.message) || 'Unknown error') + '</p>'; });
+})();
+</script>
+
+<script>
+/* iFrame auto-resize — posts content height to the parent so the embed
+   can't clip the form. Pairs with assets/js/iframe-resizer.js on the
+   WordPress side. No-op when this page is opened standalone. */
+(function () {
+  var id = (document.body && document.body.dataset && document.body.dataset.iframeId) || window.location.pathname;
+  if (window.parent === window) return;
+  function postHeight() {
+    var h = (document.documentElement && document.documentElement.scrollHeight) || (document.body && document.body.scrollHeight) || 0;
+    if (window.parent && typeof window.parent.postMessage === 'function') {
+      window.parent.postMessage({ type: 'setHeight', height: h, id: id }, '*');
+    }
+  }
+  var frameId;
+  function schedule() { if (frameId) cancelAnimationFrame(frameId); frameId = requestAnimationFrame(postHeight); }
+  window.addEventListener('load', schedule, { passive: true });
+  window.addEventListener('resize', schedule, { passive: true });
+  if (typeof MutationObserver !== 'undefined' && document.body) {
+    new MutationObserver(schedule).observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });
+  }
+  schedule();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary

The two WordPress pages behind the 2026 Treasury Tech Selection Guide waitlist embed standalone HTML files via Custom HTML iframes. Both had hardcoded `height` + `scrolling="no"`, so the waitlist form clipped its disclaimer/social-proof row and both embeds sat inside the theme's narrow content column with white side gutters.

This PR:

- Adds the standard `setHeight` postMessage child script to `treasury-tech-selection/waitlist/index.html` and `treasury-tech-selection/guide/index.html`. The parent (`assets/js/iframe-resizer.js`, already loaded site-wide) listens for the message and resizes the iframe to fit its content, so adding fields to the form schema can never clip the embed again. The child script is a no-op when the page is opened standalone (it checks `window.parent === window`).
- Switches the waitlist page body to the same dark purple radial+linear gradient already used on the confirmation page (recently shipped in #827), with the hero made transparent and title/subtitle recoloured for legibility on dark. Preview and form cards remain light, so they read as floating cards on the brand gradient — matching the rest of realtreasury.com.
- Both files still render correctly when opened directly from GitHub Pages.

## WordPress Custom HTML snippets

Both snippets use the same full-bleed wrapper trick (`100vw` + negative margin) so the dark gradient inside the iframe hits the browser edges rather than sitting inside the theme's content column. They also give the iframe `id="iframe-default"`, which is one of the default selectors `assets/js/iframe-resizer.js` matches on — no extra config needed.

### Signup page → embeds `treasury-tech-selection/waitlist/index.html`

```html
<div class="rt-fullbleed-embed" style="
  position: relative;
  left: 50%;
  right: 50%;
  width: 100vw;
  margin-left: -50vw;
  margin-right: -50vw;
  background:
    radial-gradient(900px 520px at 90% -12%, rgba(143, 71, 246, 0.28), transparent 60%),
    radial-gradient(700px 400px at 8% 110%, rgba(199, 125, 255, 0.22), transparent 64%),
    linear-gradient(180deg, #0d1632 0%, #0e152b 45%, #05070f 100%);
  overflow: hidden;
">
  <iframe
    id="iframe-default"
    data-iframe-resizer="true"
    src="https://realtreasury.github.io/rt-wordpress-content/treasury-tech-selection/waitlist/"
    title="Join the 2026 Real Treasury Tech Selection Guide Waitlist"
    loading="lazy"
    style="display:block; width:100%; border:0; background:transparent;"
    width="100%"
    height="1200"
  ></iframe>
</div>
```

### Post-submit confirmation page (`/2026-treasury-tech-guide-waitlist/`) → embeds `treasury-tech-selection/guide/index.html`

```html
<div class="rt-fullbleed-embed" style="
  position: relative;
  left: 50%;
  right: 50%;
  width: 100vw;
  margin-left: -50vw;
  margin-right: -50vw;
  background:
    radial-gradient(900px 520px at 90% -12%, rgba(143, 71, 246, 0.28), transparent 60%),
    radial-gradient(700px 400px at 8% 110%, rgba(199, 125, 255, 0.22), transparent 64%),
    linear-gradient(180deg, #0d1632 0%, #0e152b 45%, #05070f 100%);
  overflow: hidden;
">
  <iframe
    id="iframe-default"
    data-iframe-resizer="true"
    src="https://realtreasury.github.io/rt-wordpress-content/treasury-tech-selection/guide/"
    title="Waitlist Confirmation — 2026 Real Treasury Tech Selection Guide"
    loading="lazy"
    style="display:block; width:100%; border:0; background:transparent;"
    width="100%"
    height="600"
  ></iframe>
</div>
```

Notes on the snippets:

- **Drop `scrolling="no"`.** With auto-resize the iframe matches content height, and `scrolling="no"` is what was hiding the cut-off form content. The parent script will also set `overflow:hidden` once it receives the first `setHeight`, so there's no flicker.
- The `height="…"` attribute is just an initial value before the first `setHeight` lands (a few hundred ms). Pick something close to the expected first paint to avoid layout jump.
- `id="iframe-default"` is recognised by `assets/js/iframe-resizer.js` out of the box; `data-iframe-resizer="true"` is a belt-and-braces fallback in case both pages ever end up on the same page.
- The wrapper background matches the body gradient inside the iframe, so until the iframe paints there's no white flash, and on very tall viewports any rounding gap at the bottom stays on-brand.

## Other places in the repo using this pattern

The same `postMessage({type:'setHeight'})` child script + `assets/js/iframe-resizer.js` parent is already in use across the repo — these all match the shape of the new snippets:

- `templates/partials/iframe-height-script.html` — the canonical EJS partial.
- `webinars/tms-rfp-trap/index.html` (lines ~282–292) — inline IIFE version, the closest precedent for what's been added here.
- `webinars/prompt-to-product/index.html`, `webinars/3-segments-1-smart-choice/index.html`, `webinars/3-segments-1-smart-choice-emea/index.html`.
- `events/2024/{afp,dafp,gwafp,fincircle,nyce}/index.html`, `events/2025/{afp,kyriba,iofm-fall-ar,cash-management-virtual-forum}/index.html`, `events/2026/techsommet/index.html`.
- `team/index.html`, `Homepage/index.html`, `terms-of-service/index.html`, `privacy-policy/index.html`, `templates/partials/gated-video.html`.

`rt-gate` is untouched — mapping #5 already handles the post-submit redirect to the confirmation slug.

## Test plan

- [ ] Open `https://realtreasury.github.io/rt-wordpress-content/treasury-tech-selection/waitlist/` directly — page renders on the dark gradient, form loads, no console errors.
- [ ] Open `…/treasury-tech-selection/guide/` directly — unchanged confirmation card on dark gradient.
- [ ] Paste the signup-page snippet into the WP Custom HTML block, view the page — iframe is full-width, gradient hits the browser edges, no white gutters, no clipping below the "Join the Waitlist" button (disclaimer + 2026/Free/100% row visible).
- [ ] Submit the form — redirect to `/2026-treasury-tech-guide-waitlist/` works (rt-gate mapping #5).
- [ ] Paste the confirmation-page snippet into that page's Custom HTML block — confirmation card renders edge-to-edge on the dark gradient.
- [ ] Resize the browser between 320px and 1920px — iframe height tracks content, no scrollbars inside the iframe.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H9viwE5NXh7RZAgc7v3JZ7)_