### PR TITLE
Refresh treasury tech waitlist + guide pages to light brand styling

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -7,16 +7,16 @@
   <meta name="description" content="Thank you for joining the waitlist for the 2026 Real Treasury Tech Selection Guide." />
   <style>
     :root {
-      --midnight: #05070f;
-      --slate: #0e152b;
-      --panel: rgba(10, 16, 35, 0.82);
-      --text: #f8f9ff;
-      --muted: #b6bfd9;
-      --border: rgba(199, 125, 255, 0.24);
+      --page-bg-top: #faf7ff;
+      --page-bg-bottom: #f1ebff;
+      --panel: rgba(255, 255, 255, 0.98);
+      --text: #2d1450;
+      --muted: #5f5872;
+      --border: rgba(114, 22, 244, 0.2);
       --purple: #7216f4;
       --purple-2: #8f47f6;
       --pink: #c77dff;
-      --glow: rgba(114, 22, 244, 0.45);
+      --glow: rgba(114, 22, 244, 0.2);
       --success: #22c55e;
     }
 
@@ -34,7 +34,7 @@
       background:
         radial-gradient(900px 520px at 90% -12%, rgba(143, 71, 246, 0.28), transparent 60%),
         radial-gradient(700px 400px at 8% 110%, rgba(199, 125, 255, 0.22), transparent 64%),
-        linear-gradient(180deg, #0d1632 0%, var(--slate) 45%, var(--midnight) 100%);
+        linear-gradient(180deg, var(--page-bg-top) 0%, #f7f2ff 52%, var(--page-bg-bottom) 100%);
       background-attachment: fixed;
       display: flex;
       align-items: center;
@@ -48,10 +48,10 @@
       border-radius: 24px;
       padding: clamp(1.2rem, 2.2vw, 2.1rem);
       border: 1px solid var(--border);
-      background: linear-gradient(165deg, rgba(16,24,48,0.88) 0%, var(--panel) 100%);
+      background: linear-gradient(165deg, #ffffff 0%, var(--panel) 100%);
       box-shadow:
-        0 14px 50px rgba(0, 0, 0, 0.42),
-        inset 0 1px 0 rgba(255,255,255,0.08),
+        0 18px 48px rgba(91, 10, 205, 0.10),
+        inset 0 1px 0 rgba(255,255,255,0.94),
         0 0 0 1px rgba(114, 22, 244, 0.06);
       backdrop-filter: blur(4px);
       position: relative;
@@ -75,12 +75,12 @@
       font-size: .77rem;
       letter-spacing: .08em;
       text-transform: uppercase;
-      border: 1px solid rgba(255,255,255,0.22);
+      border: 1px solid rgba(114,22,244,0.26);
       border-radius: 999px;
       padding: .38rem .78rem;
       margin-bottom: .95rem;
-      color: #ede9fe;
-      background: rgba(114, 22, 244, 0.23);
+      color: #5b0acd;
+      background: rgba(114, 22, 244, 0.12);
       box-shadow: 0 0 18px rgba(114, 22, 244, 0.18);
       font-weight: 600;
     }
@@ -153,25 +153,25 @@
     }
 
     .btn-secondary {
-      border-color: rgba(255,255,255,0.25);
-      color: #e9ebff;
-      background: rgba(7, 13, 29, 0.54);
+      border-color: rgba(114,22,244,0.24);
+      color: #4d3d72;
+      background: rgba(114, 22, 244, 0.06);
     }
 
     .btn-secondary:hover {
       transform: translateY(-2px);
-      border-color: rgba(255,255,255,0.4);
-      background: rgba(255,255,255,0.08);
+      border-color: rgba(114,22,244,0.34);
+      background: rgba(114,22,244,0.1);
     }
 
     .footnote {
       margin-top: .95rem;
       font-size: .85rem;
-      color: #aeb9d6;
+      color: #6b5f8f;
     }
 
     .footnote a {
-      color: #d5b8ff;
+      color: #7216f4;
       text-underline-offset: 2px;
     }
 

--- a/treasury-tech-selection/waitlist/index.html
+++ b/treasury-tech-selection/waitlist/index.html
@@ -30,14 +30,13 @@ window.RTG_CONFIG = {
   <title>2026 Real Treasury Tech Selection Guide | Join the Waitlist</title>
   <meta name="description" content="Join the waitlist for the 2026 Real Treasury Tech Selection Guide and get notified as soon as it launches." />
   <style>
-    /* Full-bleed dark gradient so the embed looks edge-to-edge whether
-       opened standalone or hosted inside an auto-sizing iframe. */
+    /* Brand-forward light background (no dark theme) so embeds match RT pages. */
     html, body { margin: 0; padding: 0; }
     body {
         background:
-          radial-gradient(900px 520px at 90% -12%, rgba(143, 71, 246, 0.28), transparent 60%),
-          radial-gradient(700px 400px at 8% 110%, rgba(199, 125, 255, 0.22), transparent 64%),
-          linear-gradient(180deg, #0d1632 0%, #0e152b 45%, #05070f 100%);
+          radial-gradient(900px 520px at 92% -18%, rgba(143, 71, 246, 0.13), transparent 60%),
+          radial-gradient(700px 400px at 8% 108%, rgba(199, 125, 255, 0.11), transparent 62%),
+          linear-gradient(180deg, #faf7ff 0%, #f8f8ff 54%, #f2edff 100%);
         background-attachment: fixed;
         min-height: 100vh;
     }
@@ -69,9 +68,9 @@ window.RTG_CONFIG = {
     /* ---- Hero (transparent over dark body gradient) ---- */
     .rt-wl-hero { background: transparent; padding: 60px 0 48px; text-align: center; position: relative; overflow: hidden; }
     .rt-wl-hero .rt-wl-container { position: relative; z-index: 2; }
-    .rt-wl-badge { display: inline-block; background: rgba(199,125,255,0.18); border: 1px solid rgba(199,125,255,0.4); border-radius: 20px; padding: 8px 20px; font-size: 0.875rem; font-weight: 600; color: #ede9fe; margin-bottom: 24px; }
-    .rt-wl-title { font-size: 3rem; font-weight: 800; line-height: 1.15; margin-bottom: 20px; background: linear-gradient(90deg, #f8f9ff 0%, #dfc8ff 65%, #b89dff 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; padding-bottom: 0.08em; }
-    .rt-wl-subtitle { font-size: 1.15rem; color: #b6bfd9; line-height: 1.6; max-width: 720px; margin: 0 auto; font-weight: 400; }
+    .rt-wl-badge { display: inline-block; background: rgba(114,22,244,0.1); border: 1px solid rgba(114,22,244,0.28); border-radius: 20px; padding: 8px 20px; font-size: 0.875rem; font-weight: 600; color: #5b0acd; margin-bottom: 24px; }
+    .rt-wl-title { font-size: 3rem; font-weight: 800; line-height: 1.15; margin-bottom: 20px; background: linear-gradient(90deg, #2f1850 0%, #5b0acd 48%, #7216f4 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; padding-bottom: 0.08em; }
+    .rt-wl-subtitle { font-size: 1.15rem; color: #4f4c63; line-height: 1.6; max-width: 720px; margin: 0 auto; font-weight: 400; }
 
     /* ---- Side-by-side row ---- */
     .rt-wl-content-section { padding: 48px 0; }
@@ -89,7 +88,7 @@ window.RTG_CONFIG = {
     .rt-wl-features li::before { content: ''; display: inline-block; width: 18px; height: 18px; min-width: 18px; background: var(--gradient-primary); border-radius: 50%; margin-top: 2px; }
 
     /* ---- Form Card ---- */
-    .rt-wl-form-card { flex: 1 1 0; min-width: 0; background: var(--white); border: 2px solid rgba(199,125,255,0.2); border-radius: 20px; padding: 48px 40px; box-shadow: 0 8px 32px rgba(114,22,244,0.1); position: relative; overflow: hidden; }
+    .rt-wl-form-card { flex: 1 1 0; min-width: 0; background: #ffffff; border: 2px solid rgba(114,22,244,0.16); border-radius: 20px; padding: 48px 40px; box-shadow: 0 14px 36px rgba(91,10,205,0.08); position: relative; overflow: hidden; }
     .rt-wl-form-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: var(--gradient-primary); }
     .rt-wl-form-heading { font-size: 1.5rem; font-weight: 700; color: var(--dark-text); margin: 0 0 8px; text-align: center; }
     .rt-wl-form-subtext { font-size: 0.95rem; color: var(--gray-text); text-align: center; margin-bottom: 32px; }
@@ -119,7 +118,7 @@ window.RTG_CONFIG = {
     .rt-wl-form-wrap .rtg-submit-btn:active { transform: translateY(0); }
 
 
-    .rt-wl-disclaimer { font-size: 0.8rem; color: #9ca3af; text-align: center; margin-top: 16px; line-height: 1.5; }
+    .rt-wl-disclaimer { font-size: 0.8rem; color: #6b7280; text-align: center; margin-top: 16px; line-height: 1.5; }
 
     /* ---- Social proof strip ---- */
     .rt-wl-proof { display: flex; gap: 24px; margin-top: 32px; padding-top: 24px; border-top: 1px solid rgba(199,125,255,0.15); flex-wrap: wrap; }


### PR DESCRIPTION
## Summary
- Updated `treasury-tech-selection/waitlist/index.html` to remove dark/black gradients and use a lighter Real Treasury-aligned background and typography treatment.
- Updated hero badge/title/subtitle colors on the waitlist page for better contrast on light backgrounds.
- Refined waitlist form card/disclaimer tones to keep the purple brand accents while matching light-page UI.
- Updated `treasury-tech-selection/guide/index.html` (waitlist confirmation page) to replace dark theme tokens with light brand tokens.
- Adjusted confirmation card, pill, secondary button, and footnote/link styling for a cohesive light-brand presentation.

## Why
You requested that both the waitlist and treasury tech guide pages align better with brand standards and avoid dark styling.

## Scope
- Visual/CSS-only updates in two standalone HTML pages.
- No form logic or RT Gate integration behavior was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08acb698b883319485855a7b8d0e82)