### PR TITLE
Improve spacing on treasury-tech-selection guide waitlist page

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -37,16 +37,16 @@
         linear-gradient(180deg, var(--page-bg-top) 0%, #f7f2ff 52%, var(--page-bg-bottom) 100%);
       background-attachment: fixed;
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       justify-content: center;
-      padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 2vw, 1.5rem);
+      padding: clamp(2.2rem, 6vw, 5rem) clamp(1rem, 2.8vw, 2rem);
       overflow-x: hidden;
     }
 
     .card {
-      width: min(840px, 100%);
-      border-radius: 24px;
-      padding: clamp(1.2rem, 2.2vw, 2.1rem);
+      width: min(960px, 100%);
+      border-radius: 26px;
+      padding: clamp(1.4rem, 2.6vw, 2.5rem);
       border: 1px solid var(--border);
       background: linear-gradient(165deg, #ffffff 0%, var(--panel) 100%);
       box-shadow:
@@ -86,16 +86,16 @@
     }
 
     h1 {
-      margin: 0 0 .65rem;
-      font-size: clamp(1.35rem, 2.8vw, 2.35rem);
-      line-height: 1.22;
+      margin: 0 0 .8rem;
+      font-size: clamp(1.45rem, 3.1vw, 2.6rem);
+      line-height: 1.2;
       text-wrap: balance;
     }
 
     p {
-      margin: .6rem 0;
+      margin: .72rem 0;
       color: var(--muted);
-      line-height: 1.62;
+      line-height: 1.72;
       max-width: 64ch;
     }
 
@@ -107,12 +107,12 @@
     }
 
     .next-steps {
-      margin: 1.1rem 0 1.4rem;
-      padding-left: 1.1rem;
+      margin: 1.25rem 0 1.65rem;
+      padding-left: 1.25rem;
     }
 
     .next-steps li {
-      margin-bottom: .5rem;
+      margin-bottom: .58rem;
       color: var(--muted);
     }
 
@@ -122,7 +122,7 @@
       display: flex;
       flex-wrap: wrap;
       gap: .72rem;
-      margin-top: .45rem;
+      margin-top: .55rem;
     }
 
     .btn {
@@ -165,7 +165,7 @@
     }
 
     .footnote {
-      margin-top: .95rem;
+      margin-top: 1.15rem;
       font-size: .85rem;
       color: #6b5f8f;
     }
@@ -173,6 +173,15 @@
     .footnote a {
       color: #7216f4;
       text-underline-offset: 2px;
+    }
+
+    @media (max-width: 760px) {
+      body {
+        padding-top: 1.25rem;
+      }
+      .card {
+        border-radius: 20px;
+      }
     }
 
     @media (max-width: 560px) {


### PR DESCRIPTION
### Motivation
- The guide waitlist redirect page is now rendered directly (not inside an iframe) and felt visually cramped on larger and mid-size viewports, so spacing and layout needed adjustment for better readability.

### Description
- Adjusted the page root to top-align content and increased responsive outer padding via updates to `body` styles in `treasury-tech-selection/guide/index.html`.
- Increased the content card's maximum width, corner radius, and internal padding for more breathing room on desktop screens.
- Tuned typography and spacing including heading scale and margin, paragraph margin and line-height, list spacing, action spacing, and footnote separation to improve readability.
- Added a mid-breakpoint media rule at `@media (max-width: 760px)` to preserve balanced spacing and rounded corners on tablets.

### Testing
- Ran a diff review of the updated `treasury-tech-selection/guide/index.html` to validate the CSS/HTML changes and ensure no syntax issues; the diff matched the intended edits and succeeded.
- Committed the updated file to the repository; no build step or automated site render was required for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08aed8951083319943caf93d943b29)