### PR TITLE
Add contact email and strategy meeting link to guide waitlist page

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -150,7 +150,9 @@
       <li>Add Real Treasury to your safe sender list to avoid missing updates.</li>
     </ul>
 
-    <p class="footnote">If you have questions, reply to the confirmation email you received and our team will help.</p>
+    <p class="footnote">If you have any questions, email <a href="mailto:contact@realtreasury.com">contact@realtreasury.com</a> and our team will help.</p>
+
+    <p class="footnote">Want to talk sooner? <a href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2?ismsaljsauthenabled" target="_blank" rel="noopener noreferrer">Book a strategy meeting</a>.</p>
   </main>
 
   <script>


### PR DESCRIPTION
### Motivation
- Make it clear how waitlist members can get help or speak with the team by surfacing a direct contact email and a meeting booking link on the confirmation landing page.

### Description
- Update `treasury-tech-selection/guide/index.html` to replace the previous footnote with a `mailto:contact@realtreasury.com` contact link and add a secondary footnote CTA linking to the Real Treasury strategy meeting booking page.

### Testing
- Verified the updated HTML via `git diff -- treasury-tech-selection/guide/index.html` and recorded the change with `git commit`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b0e583308331ad708d4ec7c594ed)