### PR TITLE
Fix share button text overflow on TMS guide landing page

### DIFF
--- a/insights/2025/tms-selection-guide/index.html
+++ b/insights/2025/tms-selection-guide/index.html
@@ -182,6 +182,7 @@
             font-size: 0.9rem;
             min-width: 120px;
             justify-content: center;
+            white-space: nowrap;
             position: relative;
             overflow: hidden;
         }
@@ -431,6 +432,23 @@
             
             .container {
                 padding: 0 15px;
+            }
+
+            .share-buttons {
+                gap: 10px;
+            }
+
+            .share-btn {
+                flex: 1 1 calc(50% - 10px);
+                min-width: 0;
+                padding: 12px 14px;
+                font-size: 0.82rem;
+                gap: 6px;
+            }
+
+            .share-btn .copy-text {
+                display: inline-block;
+                overflow-wrap: anywhere;
             }
         }
     </style>

--- a/templates/insights/2025/tms-selection-guide/index.html
+++ b/templates/insights/2025/tms-selection-guide/index.html
@@ -182,6 +182,7 @@
             font-size: 0.9rem;
             min-width: 120px;
             justify-content: center;
+            white-space: nowrap;
             position: relative;
             overflow: hidden;
         }
@@ -431,6 +432,23 @@
             
             .container {
                 padding: 0 15px;
+            }
+
+            .share-buttons {
+                gap: 10px;
+            }
+
+            .share-btn {
+                flex: 1 1 calc(50% - 10px);
+                min-width: 0;
+                padding: 12px 14px;
+                font-size: 0.82rem;
+                gap: 6px;
+            }
+
+            .share-btn .copy-text {
+                display: inline-block;
+                overflow-wrap: anywhere;
             }
         }
     </style>


### PR DESCRIPTION
### Motivation
- The share button labels on the TMS selection guide landing page were clipping on narrow viewports, making the CTA text unreadable on mobile.
- The goal is to ensure share button labels fit cleanly while preserving the existing visual style and desktop layout.

### Description
- Added `white-space: nowrap` to the `.share-btn` base rules to keep labels on a single line in the default layout in `templates/insights/2025/tms-selection-guide/index.html` and the generated `insights/2025/tms-selection-guide/index.html`.
- Introduced mobile-specific adjustments inside `@media (max-width: 768px)` that set `.share-buttons` gap, make `.share-btn` use `flex: 1 1 calc(50% - 10px)`, reduce `padding` and `font-size`, and allow safe wrapping for copy text via `.share-btn .copy-text`.
- Applied the same CSS edits to both the EJS template and the generated HTML so runtime output and source remain in sync.

### Testing
- Located affected occurrences with a repository search using `rg` and verified the two target files were updated as expected, which completed successfully.
- Compared the modified template and generated HTML to confirm identical CSS changes were applied to both files, and no runtime build was required for this CSS-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b3c574e08331993ef22bd91d3784)