### PR TITLE
Fix guide landing CTA text overflow in buttons

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -135,6 +135,7 @@
       align-items: center;
       justify-content: center;
       padding: .62rem .95rem;
+      min-height: 2.5rem;
       border-radius: 10px;
       border: 1px solid rgba(114, 22, 244, 0.28);
       color: #ffffff;
@@ -144,7 +145,8 @@
       font-size: .84rem;
       line-height: 1.3;
       letter-spacing: .01em;
-      white-space: nowrap;
+      white-space: normal;
+      text-align: center;
       transition: transform .15s ease, box-shadow .2s ease, filter .2s ease;
       box-shadow: 0 8px 18px rgba(114, 22, 244, 0.2);
     }


### PR DESCRIPTION
### Motivation
- Ensure long CTA labels on the guide landing page wrap and remain legible instead of overflowing button bounds.

### Description
- Update `treasury-tech-selection/guide/index.html` CSS: set `.cta-button` to `white-space: normal`, `text-align: center`, and add `min-height: 2.5rem` to allow multiline, centered button text.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b3c574e08331993ef22bd91d3784)