### PR TITLE
Update guide CTA email label and add aria-label for accessibility

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -206,7 +206,7 @@
     <p class="footnote">Want to connect before launch? Reach out directly or schedule time with our team.</p>
     <div class="cta-group" role="group" aria-label="Contact options">
       <a class="cta-button" href="https://outlook.office.com/book/RealTreasuryMeeting@realtreasury.com/s/LgF7vpFIP0qANup2hPHi_g2?ismsaljsauthenabled" target="_blank" rel="noopener noreferrer">Book a strategy meeting</a>
-      <a class="cta-button secondary" href="mailto:contact@realtreasury.com">Email contact@realtreasury.com</a>
+      <a class="cta-button secondary" href="mailto:contact@realtreasury.com" aria-label="Email contact@realtreasury.com">Email our team</a>
     </div>
   </main>
 


### PR DESCRIPTION
### Motivation
- Make the secondary CTA in the waitlist guide more action-oriented and clearer to users while retaining the original email destination.

### Description
- Replaced the visible button text `Email contact@realtreasury.com` with `Email our team` in `treasury-tech-selection/guide/index.html`.
- Added `aria-label="Email contact@realtreasury.com"` to the same anchor so screen-reader users still hear the explicit destination.
- Preserved the existing `href="mailto:contact@realtreasury.com"` link target so backend/user flow is unchanged.

### Testing
- Ran `rg` to locate the CTA and confirm the original text and href were present and then updated successfully; the search succeeded.
- Verified the change with `git diff` to ensure only the intended anchor was modified and then created a commit; both commands succeeded.
- Inspected the updated file lines with `nl` to confirm the final markup shows the new text and `aria-label`; inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b5ba34cc8331ab5b90dd1b6383a8)