### PR TITLE
Adjust guide CTA button weight and padding for lighter visual feel

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -134,14 +134,14 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: .62rem .95rem;
+      padding: .56rem .88rem;
       min-height: 2.5rem;
       border-radius: 10px;
       border: 1px solid rgba(114, 22, 244, 0.28);
       color: #ffffff;
       background: linear-gradient(120deg, #7216f4 0%, #8f47f6 100%);
       text-decoration: none;
-      font-weight: 600;
+      font-weight: 500;
       font-size: .84rem;
       line-height: 1.3;
       letter-spacing: .01em;


### PR DESCRIPTION
### Motivation
- Reduce the perceived heaviness of CTA buttons on the Real Treasury Tech Selection guide while preserving accessibility and tap targets (40px+). 

### Description
- In `treasury-tech-selection/guide/index.html` updated `.cta-button` `font-weight` from `600` to `500` and tightened `padding` from `.62rem .95rem` to `.56rem .88rem`, while keeping `min-height: 2.5rem` and leaving mobile full-width behavior under `@media (max-width: 760px)` unchanged. 

### Testing
- Ran `rg -n ".cta-button|@media (max-width: 760px)" treasury-tech-selection/guide/index.html` to locate styles and confirm changes, which succeeded. 
- Inspected the updated region with `nl -ba treasury-tech-selection/guide/index.html | sed -n '120,210p'` to validate values, which succeeded. 
- Verified the diff with `git diff -- treasury-tech-selection/guide/index.html` and committed the change with `git commit -m "Tighten guide CTA button typography and spacing"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b6125cc083319de8660927b33e78)