### PR TITLE
Refine CTA button typography and spacing on guide waitlist page

### DIFF
--- a/treasury-tech-selection/guide/index.html
+++ b/treasury-tech-selection/guide/index.html
@@ -134,14 +134,14 @@
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: .62rem .95rem;
+      padding: .56rem .88rem;
       min-height: 2.5rem;
       border-radius: 10px;
       border: 1px solid rgba(114, 22, 244, 0.28);
       color: #ffffff;
       background: linear-gradient(120deg, #7216f4 0%, #8f47f6 100%);
       text-decoration: none;
-      font-weight: 600;
+      font-weight: 500;
       font-size: .84rem;
       line-height: 1.3;
       letter-spacing: .01em;
@@ -182,9 +182,14 @@
       }
     }
 
-    @media (min-width: 761px) and (max-width: 980px) {
+    @media (min-width: 761px) {
       .cta-button {
         font-size: .8rem;
+      }
+    }
+
+    @media (min-width: 761px) and (max-width: 980px) {
+      .cta-button {
         padding: .58rem .85rem;
       }
     }


### PR DESCRIPTION
### Motivation
- Reduce the visual heaviness of the call-to-action buttons on the waitlist guide while preserving accessibility and tap-target size.
- Maintain clear visual hierarchy so the primary gradient CTA remains prominent and the secondary CTA stays subordinate.

### Description
- Lowered `.cta-button` padding from ` .62rem .95rem` to ` .56rem .88rem` to slightly reduce bulk while keeping a roomy target. 
- Reduced button `font-weight` from `600` to `500` and added a desktop-only `@media (min-width: 761px)` rule to set `font-size: .8rem` for lighter perceived weight on larger viewports.
- Preserved `min-height: 2.5rem` (≈40px) to keep tap targets accessible and kept the existing mobile full-width stacking under `@media (max-width: 760px)` unchanged.
- Retained the mid-range media rule for adjusted padding between `761px` and `980px` to keep sizing consistent across breakpoints.

### Testing
- Verified the updated file contents with `sed -n '1,260p' treasury-tech-selection/guide/index.html` which succeeded.
- Inspected the CSS section with `nl -ba /workspace/rt-wordpress-content/treasury-tech-selection/guide/index.html | sed -n '120,210p'` which succeeded and shows the new rules.
- Attempted a visual snapshot via `npx playwright screenshot file:///workspace/rt-wordpress-content/treasury-tech-selection/guide/index.html /tmp/guide-cta.png`, which failed because Playwright browsers were not installed in the environment (error advises running `npx playwright install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08b6125cc083319de8660927b33e78)