### PR TITLE
Fix waitlist gated form: top-window redirect + restore iframe auto-resize

### DIFF
--- a/treasury-tech-selection/waitlist/index.html
+++ b/treasury-tech-selection/waitlist/index.html
@@ -340,6 +340,15 @@ window.RTG_CONFIG = {
             return;
           }
           if (resp) { resp.className = 'rtg-response rtg-success'; resp.textContent = 'Success! Redirecting...'; }
+          // When embedded in an iframe, navigate the top window so the
+          // user actually leaves the waitlist page instead of loading
+          // the destination inside the form embed.
+          try {
+            if (window.top && window.top !== window.self) {
+              window.top.location.href = target;
+              return;
+            }
+          } catch (e) { /* cross-origin parent; fall through */ }
           window.location.href = target;
         })
         .catch(function(err){ if (btn) btn.disabled = false; if (resp) { resp.className = 'rtg-response rtg-error'; resp.textContent = (err && err.message) || 'Submission failed.'; } });
@@ -352,5 +361,29 @@ window.RTG_CONFIG = {
 })();
 </script>
 
+<script>
+/* iFrame auto-resize — posts content height to the parent so the embed
+   can't clip the form below the submit button. Pairs with
+   assets/js/iframe-resizer.js on the WordPress side. No-op when this
+   page is opened standalone. */
+(function () {
+  if (window.parent === window) return;
+  var id = (document.body && document.body.dataset && document.body.dataset.iframeId) || window.location.pathname;
+  function postHeight() {
+    var h = (document.documentElement && document.documentElement.scrollHeight) || (document.body && document.body.scrollHeight) || 0;
+    if (window.parent && typeof window.parent.postMessage === 'function') {
+      window.parent.postMessage({ type: 'setHeight', height: h, id: id }, '*');
+    }
+  }
+  var frameId;
+  function schedule() { if (frameId) cancelAnimationFrame(frameId); frameId = requestAnimationFrame(postHeight); }
+  window.addEventListener('load', schedule, { passive: true });
+  window.addEventListener('resize', schedule, { passive: true });
+  if (typeof MutationObserver !== 'undefined' && document.body) {
+    new MutationObserver(schedule).observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });
+  }
+  schedule();
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The link-asset post-submit redirect was navigating the embedded iframe instead of the top window, so the destination guide page rendered *inside* the waitlist form instead of taking the user there.
- The setHeight postMessage child script (paired with `assets/js/iframe-resizer.js`) was previously dropped in a styling refresh, causing the form to be clipped at the bottom (the "Join the Waitlist" button gets cut off behind the cookie banner).

## Changes
- `treasury-tech-selection/waitlist/index.html`
  - After `/submit` success, navigate `window.top.location.href` (with a same-origin try/catch fallback to `window.location.href`) so the user actually leaves the waitlist page.
  - Re-add the iframe auto-resize child script so the parent iframe sizes to content and the submit button is no longer clipped.

## Test plan
- [ ] Open `/2026-treasury-tech-guide-waitlist/`; verify the full form including the submit button is visible (no clipping).
- [ ] Submit the form; verify the browser navigates to the configured guide URL at the top level (URL bar changes, page is no longer the waitlist).
- [ ] Open `treasury-tech-selection/waitlist/index.html` standalone; verify it still renders and submits correctly (resize script no-ops when not embedded).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsBNkA7Axt9w7mLGJFCkx6)_