### PR TITLE
Update waitlist CTA to point to live 2026 waitlist page

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -454,7 +454,7 @@ body.banner-minimized .rt-nav-container {
         </div>
 
         <div class="banner-actions">
-            <a href="/treasury-tech-selection/waitlist/" class="banner-cta" onclick="registerLive(event)">
+            <a href="https://realtreasury.com/2026-treasury-tech-guide-waitlist/" class="banner-cta" onclick="registerLive(event)">
                 Join the Waitlist
                 <span>→</span>
             </a>
@@ -464,7 +464,7 @@ body.banner-minimized .rt-nav-container {
     <div class="site-content"></div>
 
 <script>
-const LIVE_WEBINAR_REGISTRATION_URL = '/treasury-tech-selection/waitlist/';
+const LIVE_WEBINAR_REGISTRATION_URL = 'https://realtreasury.com/2026-treasury-tech-guide-waitlist/';
 
 // Add banner state management
 function updateBannerState() {


### PR DESCRIPTION
### Motivation
- The site banner's waitlist CTA and its JS redirect were pointing to an internal relative path instead of the live 2026 waitlist URL, so clicks and script redirects needed to target the public live page.

### Description
- Changed the banner anchor `href` in `header/main-menu/index.html` to `https://realtreasury.com/2026-treasury-tech-guide-waitlist/`.
- Updated the `LIVE_WEBINAR_REGISTRATION_URL` constant in the same file to the live URL so JS-driven redirects go to the correct destination.

### Testing
- Ran `rg -n "2026-treasury-tech-guide-waitlist|LIVE_WEBINAR_REGISTRATION_URL|Join the Waitlist" header/main-menu/index.html` to confirm the new URL appears in the file and the search succeeded.
- Reviewed the diff with `git diff -- header/main-menu/index.html` and inspected the file lines with `nl -ba header/main-menu/index.html | sed -n '452,472p'` to verify the anchor and JS constant were updated.
- Committed the change, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ee2ac6e083318e59c1081d5be7ac)