### PR TITLE
Remove outdated feature bullets from selection guide waitlist page

### DIFF
--- a/treasury-tech-selection/waitlist/index.html
+++ b/treasury-tech-selection/waitlist/index.html
@@ -81,10 +81,6 @@ window.RTG_CONFIG = {
     .rt-wl-preview-label strong { display: block; font-size: 1rem; font-weight: 700; margin: 0 0 4px 0; white-space: nowrap; }
     .rt-wl-preview-label span { display: block; font-size: 1.1rem; color: var(--lavender-pink); font-weight: 600; opacity: 0.95; margin: 0; }
     .rt-wl-preview img { width: 100%; height: auto; border-radius: 10px; display: block; margin-top: 18px; }
-    .rt-wl-features { list-style: none; padding: 0; margin: 20px 0 0; }
-    .rt-wl-features li { display: flex; align-items: flex-start; gap: 10px; padding: 10px 0; border-top: 1px solid rgba(199,125,255,0.15); font-size: 0.95rem; color: var(--dark-text); }
-    .rt-wl-features li:first-child { border-top: none; }
-    .rt-wl-features li::before { content: ''; display: inline-block; width: 18px; height: 18px; min-width: 18px; background: var(--gradient-primary); border-radius: 50%; margin-top: 2px; }
 
     /* ---- Form Card ---- */
     .rt-wl-form-card { flex: 1 1 0; min-width: 0; background: #ffffff; border: 2px solid rgba(114,22,244,0.16); border-radius: 20px; padding: 48px 40px; box-shadow: 0 14px 36px rgba(91,10,205,0.08); position: relative; overflow: hidden; }
@@ -169,12 +165,6 @@ window.RTG_CONFIG = {
             alt="Treasury Tech Market Map — North America, preview of the 2026 Real Treasury Tech Selection Guide"
             loading="lazy"
           >
-          <ul class="rt-wl-features">
-            <li>Early-access notification the day it goes live</li>
-            <li>Actionable vendor evaluation scorecards</li>
-            <li>Independent, practitioner-led selection criteria</li>
-            <li>Implementation insights from real deployments</li>
-          </ul>
         </div>
 
         <!-- Right: Waitlist sign-up form card -->


### PR DESCRIPTION
### Motivation
- The left-hand feature bullet list on the Selection Guide waitlist page was inaccurate and should no longer be shown to visitors.

### Description
- Removed the `<ul class="rt-wl-features">` block from `treasury-tech-selection/waitlist/index.html` so the preview card no longer displays the outdated bullets.
- Deleted the accompanying `.rt-wl-features` CSS rules from the same file to remove unused styles.
- Changes were committed with the message `Remove waitlist feature bullets from selection guide page`.

### Testing
- Ran `rg -n "rt-wl-features|Early-access notification|Actionable vendor" treasury-tech-selection/waitlist/index.html` to confirm the list and text were removed, which succeeded.
- Inspected the modified file with `sed`/`nl` to verify the list and CSS rules are gone, which succeeded.
- Verified the change was staged and recorded with `git commit` and `git status --short`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08f3f2571c8331bfd0c3fc51d28038)