### PR TITLE
Update EMEA chart image references to May 2026 asset

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -1135,7 +1135,7 @@
                                     <h3>Treasury Systems</h3>
                                     <p>EMEA Vendors</p>
                                 </div>
-                                <img src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-clean-EMEA-01-2026-1.png" alt="Treasury Tech Market Map - EMEA">
+                                <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-clean-EMEA-05-2026.png" alt="Treasury Tech Market Map - EMEA">
                             </a>
                         </div>
                         <div class="carousel-dots">

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -50,7 +50,7 @@ function add_my_custom_header_html() {
                                                     <p>EMEA Vendors</p>
                                                 </div>
                                                 <img class="rt-explore-image"
-                                                    src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-clean-EMEA-01-2026-1.png"
+                                                    src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-clean-EMEA-05-2026.png"
                                                      alt="Treasury Tech Market - EMEA">
                                             </a>
                                         </div>

--- a/treasury-tech-market/index.html
+++ b/treasury-tech-market/index.html
@@ -713,7 +713,7 @@
                             <h3>Treasury Systems</h3>
                             <p>EMEA Vendors</p>
                         </div>
-                        <img src="https://realtreasury.com/wp-content/uploads/2026/02/tms-market-clean-EMEA-01-2026-1.png" alt="Treasury Tech Market Map - EMEA" loading="lazy">
+                        <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-clean-EMEA-05-2026.png" alt="Treasury Tech Market Map - EMEA" loading="lazy">
                     </div>
                 </div>
             </div>

--- a/webinars/3-segments-1-smart-choice-emea/index.html
+++ b/webinars/3-segments-1-smart-choice-emea/index.html
@@ -204,7 +204,7 @@ window.RTG_CONFIG = {
             <div id="rtGvContentRow" class="rt-gv-content-row">
             <div class="rt-gv-chart">
                 <p class="rt-gv-chart-label">TMS Market Landscape — EMEA</p>
-                <img src="https://i0.wp.com/realtreasury.com/wp-content/uploads/2026/02/tms-market-clean-EMEA-01-2026-1.png" alt="TMS Market Landscape - EMEA, January 2026" loading="lazy">
+                <img src="https://realtreasury.com/wp-content/uploads/2026/05/tms-market-clean-EMEA-05-2026.png" alt="TMS Market Landscape - EMEA, May 2026" loading="lazy">
             </div>
             <div id="rtGvFormCard" class="rt-gv-form-card" role="region" aria-labelledby="rt-gv-form-heading">
                 <h3 id="rt-gv-form-heading" class="rt-gv-form-heading"></h3>


### PR DESCRIPTION
### Motivation
- Ensure the site surfaces show the latest EMEA market map by switching to the May 2026 asset URL.
- Keep image alt text consistent with the new asset date to avoid stale copy on gated pages.

### Description
- Replaced the old EMEA image URL with `https://realtreasury.com/wp-content/uploads/2026/05/tms-market-clean-EMEA-05-2026.png` in `Homepage/index.html`, `header/main-menu/custom-header.php`, `treasury-tech-market/index.html`, and `webinars/3-segments-1-smart-choice-emea/index.html`.
- Normalized the webinar image reference by removing the `i0.wp.com` proxy URL and updating the alt text from `January 2026` to `May 2026`.
- Committed the changes with the message `Update EMEA chart image to May 2026 asset` on branch `work`.

### Testing
- Verified updated references with `rg` to confirm the new URL appears in the touched files and the old URL is no longer present.
- Inspected diffs with `git diff` to review the four updated files and then ran `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b410b8d588331a93c74a6b35d5fa5)