### PR TITLE
Update Tim Schultz headshot to June 2026 asset

### DIFF
--- a/Homepage/index.html
+++ b/Homepage/index.html
@@ -1230,7 +1230,7 @@
                 <!-- Tim's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/08/Tim-Schultz-website-headshot.webp" alt="Homepage headshot of Tim Schultz, Co-Founder">
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2026/06/TS-Headshot.webp" alt="Homepage headshot of Tim Schultz, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL Consultant</div>
                     <h3 class="team-name">Tim</h3>

--- a/errnot/index.html
+++ b/errnot/index.html
@@ -576,7 +576,7 @@
                 <!-- Tim's Bio -->
                 <div class="glass-card rounded-2xl p-8 text-center relative">
                     <div class="w-40 h-40 mx-auto mb-6 rounded-full overflow-hidden border-4 border-purple-600 transition-all duration-300 hover:border-purple-400 hover:shadow-lg hover:scale-105">
-                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/08/Tim-Schultz-website-headshot.webp"
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2026/06/TS-Headshot.webp"
                              alt="ERR NOT Method page headshot of Tim Schultz, Co-Founder"
                              class="w-full h-full object-cover">
                     </div>

--- a/header/main-menu/custom-header.php
+++ b/header/main-menu/custom-header.php
@@ -232,7 +232,7 @@ function add_my_custom_header_html() {
                                     <div class="rt-founders-grid">
                                         <div class="rt-founder-card">
                                             <div class="rt-founder-image">
-                                                <img src="https://realtreasury.com/wp-content/uploads/2025/08/Tim-Schultz-website-headshot.webp"
+                                                <img src="https://realtreasury.com/wp-content/uploads/2026/06/TS-Headshot.webp"
                                                      alt="Tim Schultz" loading="lazy">
                                             </div>
                                             <div class="rt-founder-info">

--- a/insights/2024/real-treasury-explained/index.html
+++ b/insights/2024/real-treasury-explained/index.html
@@ -861,7 +861,7 @@
                 <!-- Tim -->
                 <div class="team-card">
                     <div class="team-image">
-                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/08/Tim-Schultz-website-headshot.webp" alt="Tim Schultz, Co-Founder of Real Treasury">
+                        <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2026/06/TS-Headshot.webp" alt="Tim Schultz, Co-Founder of Real Treasury">
                     </div>
                     <div class="team-role">Co-Founder & Principal Consultant</div>
                     <h3 class="team-name">Tim</h3>

--- a/team/index.html
+++ b/team/index.html
@@ -800,7 +800,7 @@
                 <!-- Tim's Bio -->
                 <div class="team-card">
                     <div class="team-image">
-                            <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2025/08/Tim-Schultz-website-headshot.webp" alt="Team page headshot of Tim Schultz, Co-Founder">
+                            <img loading="lazy" src="https://realtreasury.com/wp-content/uploads/2026/06/TS-Headshot.webp" alt="Team page headshot of Tim Schultz, Co-Founder">
                     </div>
                     <div class="team-role">Co-Founder & PRINCIPAL Consultant</div>
                     <h3 class="team-name">Tim</h3>


### PR DESCRIPTION
### Motivation
- Replace an outdated headshot URL with the new June 2026 WebP asset to keep site imagery current.
- Ensure the new image is used consistently across header and all pages that display Tim Schultz's headshot.

### Description
- Replaced `https://realtreasury.com/wp-content/uploads/2025/08/Tim-Schultz-website-headshot.webp` with `https://realtreasury.com/wp-content/uploads/2026/06/TS-Headshot.webp` across the codebase.
- Updated the following files: `Homepage/index.html`, `team/index.html`, `errnot/index.html`, `insights/2024/real-treasury-explained/index.html`, and `header/main-menu/custom-header.php`.
- Preserved existing `loading="lazy"` and `alt` attributes on each `<img>` to maintain accessibility and performance.

### Testing
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40985b50448331b9ee7235f89bd40f)