### PR TITLE
Promote upcoming webinar in main menu banner

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -383,14 +383,56 @@ body.banner-minimized .rt-nav-container {
     top: 60px !important;
 }
 
-/* Hide banner entirely on mobile */
+/* Keep time-sensitive webinar CTA visible on mobile in a compact layout */
 @media (max-width: 768px) {
     .workshop-banner {
+        display: flex !important;
+        align-items: flex-start;
+        gap: 12px;
+        min-height: 112px !important;
+        padding: 12px 16px !important;
+    }
+
+    .banner-content {
+        gap: 12px;
+        min-width: 0;
+    }
+
+    .banner-title {
+        font-size: 1rem;
+        padding-right: 28px;
+    }
+
+    .banner-subtitle {
+        font-size: 0.78rem;
+        line-height: 1.25;
+    }
+
+    .banner-actions {
+        align-self: center;
+    }
+
+    .banner-cta {
+        padding: 9px 12px;
+        font-size: 0.75rem;
+        min-width: 108px;
+    }
+
+    .workshop-banner.minimized {
+        min-height: 60px !important;
+        padding: 10px 14px !important;
+    }
+
+    .workshop-banner.minimized .banner-subtitle {
         display: none !important;
     }
 
+    body.banner-present .rt-nav-container {
+        top: 112px !important;
+    }
+
     body.banner-minimized .rt-nav-container {
-        top: 20px !important;
+        top: 60px !important;
         height: 70px !important;
     }
 
@@ -441,21 +483,21 @@ body.banner-minimized .rt-nav-container {
         <button class="close-btn" onclick="closeBanner(event)" aria-label="Close banner">&times;</button>
         
         <div class="banner-content">
-            <div class="banner-icon">📘</div>
+            <div class="banner-icon">🎥</div>
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">2026 Real Treasury Tech Selection Guide</span>
+                    <span class="banner-highlight">Live Webinar: The TMS Marketplace in Motion</span>
                 </div>
                 <div class="banner-subtitle">
-                    The practitioner-led guide to evaluating and selecting treasury technology — join the waitlist for early access.
+                    Join Tracey Knight on Wednesday, July 22 at 1 ET / 10 PT for 4 buyer considerations in today’s TMS market.
                 </div>
             </div>
         </div>
 
         <div class="banner-actions">
-            <a href="https://realtreasury.com/2026-treasury-tech-guide-waitlist/" class="banner-cta" onclick="registerLive(event)">
-                Join the Waitlist
+            <a href="https://events.teams.microsoft.com/event/a17ef281-9391-4b57-88a1-98e0daeb1986@cdc422ca-d271-4ba3-856d-77081c6a7f04" class="banner-cta" onclick="registerLive(event)">
+                Register Now
                 <span>→</span>
             </a>
         </div>
@@ -464,7 +506,7 @@ body.banner-minimized .rt-nav-container {
     <div class="site-content"></div>
 
 <script>
-const LIVE_WEBINAR_REGISTRATION_URL = 'https://realtreasury.com/2026-treasury-tech-guide-waitlist/';
+const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/a17ef281-9391-4b57-88a1-98e0daeb1986@cdc422ca-d271-4ba3-856d-77081c6a7f04';
 
 // Add banner state management
 function updateBannerState() {
@@ -538,13 +580,6 @@ window.addEventListener('load', function() {
     const banner = document.getElementById('workshopBanner');
     if (!banner) return;
 
-    if (isMobileDevice()) {
-        banner.style.display = 'none';
-        document.body.classList.add('banner-closed');
-        updateBannerState(); // Add this line
-        return;
-    }
-
     document.body.classList.add('banner-present'); // Add this line
     updateBannerState(); // Add this line
 
@@ -579,18 +614,7 @@ window.addEventListener('load', function() {
 });
 
 window.addEventListener('resize', function() {
-    const banner = document.getElementById('workshopBanner');
-    if (!banner) return;
-    
-    if (isMobileDevice()) {
-        banner.style.display = 'none';
-        document.body.classList.add('banner-closed');
-    } else {
-        if (banner.style.display === 'none') {
-            banner.style.display = '';
-            document.body.classList.remove('banner-closed');
-        }
-    }
+    updateBannerState();
 });
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Replace an out-of-date waitlist banner with a time-sensitive registration CTA for the upcoming live webinar so users can register directly from the site.

### Description
- Updated `header/main-menu/index.html` banner copy and icon to `🎥`, `Live Webinar: The TMS Marketplace in Motion`, and the webinar subtitle for Tracey Knight. 
- Replaced the CTA text with `Register Now` and updated the CTA `href` and `LIVE_WEBINAR_REGISTRATION_URL` to the Microsoft Teams registration URL `https://events.teams.microsoft.com/event/a17ef281-9391-4b57-88a1-98e0daeb1986@cdc422ca-d271-4ba3-856d-77081c6a7f04` so background clicks and the button both route to registration.
- Kept banner interactivity but changed mobile behavior: removed the previous mobile hide rule and added compact mobile styles so the webinar CTA remains visible on small screens.
- Simplified resize handling to call `updateBannerState()` and ensured banner state is initialized on load.

### Testing
- Ran `npm run test:ejs`, which completed successfully and printed the installed EJS version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455cdd12a083319933618cbdba4e03)