### PR TITLE
Update live webinar banner title, subtitle, and registration URL

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -487,16 +487,16 @@ body.banner-minimized .rt-nav-container {
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Live Webinar: The TMS Marketplace in Motion</span>
+                    <span class="banner-highlight">Live Webinar: Is Your TMS on Life Support?</span>
                 </div>
                 <div class="banner-subtitle">
-                    Join Tracey Knight on Wednesday, July 22 at 1 ET / 10 PT for 4 buyer considerations in today’s TMS market.
+                    Wednesday, July 22 at 2:00 PM — Know when it’s time to move on from a dead or dying TMS, how the marketplace is evolving, and how to find the best-fit replacement.
                 </div>
             </div>
         </div>
 
         <div class="banner-actions">
-            <a href="https://events.teams.microsoft.com/event/a17ef281-9391-4b57-88a1-98e0daeb1986@cdc422ca-d271-4ba3-856d-77081c6a7f04" class="banner-cta" onclick="registerLive(event)">
+            <a href="https://events.teams.microsoft.com/event/87f6d253-b02e-455a-b3cf-960fcc8217a9@cdc422ca-d271-4ba3-856d-77081c6a7f04" class="banner-cta" onclick="registerLive(event)">
                 Register Now
                 <span>→</span>
             </a>
@@ -506,7 +506,7 @@ body.banner-minimized .rt-nav-container {
     <div class="site-content"></div>
 
 <script>
-const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/a17ef281-9391-4b57-88a1-98e0daeb1986@cdc422ca-d271-4ba3-856d-77081c6a7f04';
+const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/87f6d253-b02e-455a-b3cf-960fcc8217a9@cdc422ca-d271-4ba3-856d-77081c6a7f04';
 
 // Add banner state management
 function updateBannerState() {


### PR DESCRIPTION
### Motivation
- Refresh the main-menu workshop banner to advertise the updated TMS webinar title and concise details.
- Point the banner CTA and client-side constant to the new Teams registration event.

### Description
- Updated the banner title string to `Live Webinar: Is Your TMS on Life Support?` in `header/main-menu/index.html`.
- Replaced the banner subtitle with a shorter event summary: `Wednesday, July 22 at 2:00 PM — Know when it’s time to move on from a dead or dying TMS, how the marketplace is evolving, and how to find the best-fit replacement.`
- Replaced both registration URL references (the `<a class="banner-cta" href=...>` and the `LIVE_WEBINAR_REGISTRATION_URL` JavaScript constant) with the new Teams event URL `https://events.teams.microsoft.com/event/87f6d253-b02e-455a-b3cf-960fcc8217a9@cdc422ca-d271-4ba3-856d-77081c6a7f04`.
- Changes are limited to `header/main-menu/index.html` and were committed.

### Testing
- Ran `rg -n "a17ef281-9391-4b57-88a1-98e0daeb1986" . || true` to confirm the old Teams event ID no longer appears and the search returned no matches.
- Verified the updated lines with `nl -ba header/main-menu/index.html | sed -n '486,510p'` and inspected the `git diff` output to confirm the intended edits.
- Committed the change with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e59dc47a48331aadbf5c6554c5594)