### PR TITLE
Update workshop banner subtitle

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -148,7 +148,7 @@ body.banner-closed { min-height: auto; }
     white-space: nowrap !important;
     overflow: hidden !important;
     text-overflow: ellipsis !important;
-    max-width: clamp(150px, 50vw, 380px) !important;
+    max-width: clamp(220px, 45vw, 620px) !important;
 }
 
 .workshop-banner.minimized .banner-cta {
@@ -490,7 +490,7 @@ body.banner-minimized .rt-nav-container {
                     <span class="banner-highlight">Live Webinar: Is Your TMS on Life Support?</span>
                 </div>
                 <div class="banner-subtitle">
-                    Wednesday, July 22 at 2:00 PM — Know when it’s time to move on from a dead or dying TMS, how the marketplace is evolving, and how to find the best-fit replacement.
+                    Wednesday, July 22 at 2:00 PM — Learn when to replace a dying TMS and how to choose the right fit.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
### Motivation
- Shorten the workshop banner subtitle so it fits on one line in the expanded header and remains legible in the minimized banner state without crowding the CTA.

### Description
- Replace the long subtitle string in `header/main-menu/index.html` with the shorter copy: `Wednesday, July 22 at 2:00 PM — Learn when to replace a dying TMS and how to choose the right fit.`
- Increase the minimized banner subtitle `max-width` from `clamp(150px, 50vw, 380px)` to `clamp(220px, 45vw, 620px)` in `header/main-menu/index.html` to keep the shorter text readable on desktop.

### Testing
- Ran `npm run test:ejs` and it completed successfully. 
- Verified the previous long phrase with `rg -n "Know when it’s time to move on from a dead or dying TMS" . --glob '!node_modules/**'` and confirmed there are no matches. 
- Performed a layout-width sanity check using a Python font measurement script for expanded and minimized desktop banner states and the measurements passed. 
- Attempted automated browser-based screenshot verification via Playwright/Chromium, but the browser installation failed in this environment (Playwright CDN returned 403), so screenshot verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e5b20efa08331b49feec2d265bc77)