### PR TITLE
fix(afp): correct worksheet ctaUrl to the real uploaded filename

### DIFF
--- a/webinars/err-not-demo-script/index.html
+++ b/webinars/err-not-demo-script/index.html
@@ -118,7 +118,7 @@ window.RTG_CONFIG = {
     // form below unlocks BOTH the video and the worksheet — the worksheet is a
     // direct file link revealed after submit, never a second form. Do not point
     // ctaUrl at a HubSpot/other form.
-    ctaUrl:       'https://realtreasury.com/wp-content/uploads/2026/07/AFP-Real-Treasury-Demo-Script-Worksheet.docx',
+    ctaUrl:       'https://realtreasury.com/wp-content/uploads/2026/07/AFP_Real_Treasury_Demo_Script_Worksheet.docx',
     ctaLabel:     'Download the ERR NOT Worksheet',
     videoTitle:   'How to Build a Demo Script That Actually Lands',
     wpSiteUrl:    'https://realtreasury.com'


### PR DESCRIPTION
Follow-up to #856, which merged while the worksheet was still being uploaded.

#856 shipped `ctaUrl` pointing at a **predicted** filename, on the assumption WordPress would sanitize underscores to hyphens. It didn't — the real upload kept them:

```
- AFP-Real-Treasury-Demo-Script-Worksheet.docx   (guessed, 404s)
+ AFP_Real_Treasury_Demo_Script_Worksheet.docx   (actual)
```

As of `main` today the download button on the ERR NOT page points at a URL that does not exist. No live impact yet — the page is still unpublished (404 on realtreasury.com) — but this must land before it is pasted into WordPress.

## Verified

```
HTTP/2 200
content-type: application/vnd.openxmlformats-officedocument.wordprocessingml.document
content-length: 239303
```

Downloaded the live file and compared it to the SharePoint original — byte-identical, `sha256 1ae029fd3d66a4143f5fda7886b9bfad7f13bb7e2d342ff28cc3a28dd3a955ad`. DOCX was accepted by the Media Library despite the library being all PDFs to date, so no MIME workaround was needed and the worksheet stays fill-in-able.

🤖 Generated with [Claude Code](https://claude.com/claude-code)