### PR TITLE
Update webinar banner for August 20

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -487,10 +487,10 @@ body.banner-minimized .rt-nav-container {
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Live Webinar: Is Your TMS on Life Support?</span>
+                    <span class="banner-highlight">Upcoming Webinar — August 20, 2026</span>
                 </div>
                 <div class="banner-subtitle">
-                    Wednesday, July 22 at 2:00 PM — Learn when to replace a dying TMS and how to choose the right fit.
+                    Join us for our upcoming webinar. Register now to reserve your place.
                 </div>
             </div>
         </div>

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -496,7 +496,7 @@ body.banner-minimized .rt-nav-container {
         </div>
 
         <div class="banner-actions">
-            <a href="https://events.teams.microsoft.com/event/87f6d253-b02e-455a-b3cf-960fcc8217a9@cdc422ca-d271-4ba3-856d-77081c6a7f04" class="banner-cta" onclick="registerLive(event)">
+            <a href="https://events.teams.microsoft.com/event/298a29ba-e836-40f1-851b-f1c35bc87aac@cdc422ca-d271-4ba3-856d-77081c6a7f04" class="banner-cta" onclick="registerLive(event)">
                 Register Now
                 <span>→</span>
             </a>
@@ -506,7 +506,7 @@ body.banner-minimized .rt-nav-container {
     <div class="site-content"></div>
 
 <script>
-const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/87f6d253-b02e-455a-b3cf-960fcc8217a9@cdc422ca-d271-4ba3-856d-77081c6a7f04';
+const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/298a29ba-e836-40f1-851b-f1c35bc87aac@cdc422ca-d271-4ba3-856d-77081c6a7f04';
 
 // Add banner state management
 function updateBannerState() {


### PR DESCRIPTION
## Summary

- replace the stale July webinar banner copy with the upcoming August 20, 2026 webinar date
- keep the supplied Microsoft Teams registration link and existing banner behavior unchanged

## Verification

- `git diff --check` passes
- single-file content-only change in `header/main-menu/index.html`

The webinar title, time, and topic were not supplied, so the banner uses date-only copy without inventing event details.