### PR TITLE
Add webinar title to August 20 banner

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -487,10 +487,10 @@ body.banner-minimized .rt-nav-container {
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Upcoming Webinar — August 20, 2026</span>
+                    <span class="banner-highlight">Live Webinar: Is Your TMS on Life Support? Know When It's Time to Move On and How to Do It</span>
                 </div>
                 <div class="banner-subtitle">
-                    Join us for our upcoming webinar. Register now to reserve your place.
+                    August 20, 2026, 2:00–2:30 PM ET — Register now to reserve your place.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- add the exact August 20 webinar title to the sitewide banner
- show the confirmed calendar time: August 20, 2026, 2:00–2:30 PM ET
- preserve the corrected registration URL from PR #860

## Verification

- `git diff --check` passes
- the old July registration URL is absent
- content-only change in `header/main-menu/index.html`