### PR TITLE
Add Tracey headshot to webinar banner

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -205,6 +205,15 @@ body.banner-closed { min-height: auto; }
     overflow: hidden;
 }
 
+.banner-speaker img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center 20%;
+    display: block;
+    transform: scale(1.18);
+}
+
 .banner-icon:before {
     content: "";
     position: absolute;
@@ -483,7 +492,9 @@ body.banner-minimized .rt-nav-container {
         <button class="close-btn" onclick="closeBanner(event)" aria-label="Close banner">&times;</button>
         
         <div class="banner-content">
-            <div class="banner-icon">🎥</div>
+            <div class="banner-icon banner-speaker">
+                <img src="https://realtreasury.com/wp-content/uploads/2025/08/TraceyHeadshot-3.webp" alt="Tracey Knight, webinar presenter">
+            </div>
 
             <div class="banner-text">
                 <div class="banner-title">


### PR DESCRIPTION
Adds Tracey Knight’s existing approved site headshot to the August 20 webinar registration banner. The image remains alongside the existing Register Now CTA and is responsive in full, minimized, and mobile banner states.

Validation: git diff --check passed. The repository’s EJS smoke test could not run because dependencies are not installed in the worktree.