### PR TITLE
docs: disclose newsletter data practices

### DIFF
--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -235,7 +235,7 @@
             
             <div class="effective-date">
                 <strong>Effective Date:</strong> June 21, 2025<br>
-                <strong>Last Updated:</strong> June 21, 2025
+                <strong>Last Updated:</strong> August 14, 2026
             </div>
 
             <div class="privacy-highlight">
@@ -251,6 +251,7 @@
                 <li><strong>Account Information:</strong> Username, password, profile information</li>
                 <li><strong>Communication Data:</strong> Messages you send us, feedback, survey responses</li>
                 <li><strong>Video Access Requests:</strong> Information submitted through our video access forms</li>
+                <li><strong>Newsletter Subscription Information:</strong> Email address, signup source, and the date and time of consent for our opt-in newsletter</li>
                 <li><strong>Payment Information:</strong> Billing details for any paid services (processed securely through third-party payment processors)</li>
             </ul>
 
@@ -298,7 +299,7 @@
                     <tr>
                         <td>Marketing communications</td>
                         <td>Consent</td>
-                        <td>Contact info, preferences</td>
+                        <td>Contact info, newsletter preferences, consent record</td>
                     </tr>
                     <tr>
                         <td>Legal compliance</td>
@@ -316,11 +317,13 @@
             <p>We work with trusted third-party service providers who help us operate our website and provide services to you, including:</p>
             <ul>
                 <li>Web hosting and content delivery</li>
-                <li>Email communication services</li>
+                <li>Email communication services, including Resend for our opt-in newsletter</li>
                 <li>Analytics and website optimization</li>
                 <li>Payment processing</li>
                 <li>Customer support tools</li>
             </ul>
+
+            <p>For our opt-in newsletter, Resend processes subscription information on our behalf so that we can manage contacts and deliver the emails you request. We do not add cold outreach, Salesforce, or Apollo contacts to the newsletter without their separate opt-in.</p>
 
             <h3>Legal Requirements</h3>
             <p>We may disclose your information when required by law, court order, or to:</p>
@@ -373,6 +376,7 @@
                 <li>Opt-out of marketing emails</li>
                 <li>Manage communication preferences</li>
                 <li>Unsubscribe from newsletters</li>
+                <li>Receive the newsletter only after opting in</li>
             </ul>
 
             <h2>6. Cookies and Tracking Technologies</h2>
@@ -387,6 +391,7 @@
                 <li><strong>Account Data:</strong> Retained while your account is active and for 3 years after closure</li>
                 <li><strong>Communication Records:</strong> Retained for 5 years for customer service purposes</li>
                 <li><strong>Usage Data:</strong> Typically retained for 2 years for analytics purposes</li>
+                <li><strong>Newsletter Subscription Information:</strong> Retained as needed to administer your subscription, honor unsubscribe requests, and meet applicable obligations</li>
                 <li><strong>Legal Requirements:</strong> Retained as required by applicable laws</li>
             </ul>
 


### PR DESCRIPTION
## Summary
- names Resend as the opt-in newsletter service provider
- discloses email, signup source, and consent timestamp collection
- documents separate opt-in, unsubscribe, and newsletter-data retention handling
- updates the policy date

## Validation
- `git diff --check` passed
- `npm run test:ejs` could not run because local dependencies are absent (`ejs` is not installed); this change is static HTML only

Owner review and merge required; no production content has been published by this branch.