### PR TITLE
Point site banner at the Treasury Tech Virtual Forum

### DIFF
--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -427,6 +427,10 @@ body.banner-minimized .rt-nav-container {
         min-width: 108px;
     }
 
+    .banner-text {
+        min-width: 0;
+    }
+
     .workshop-banner.minimized {
         min-height: 60px !important;
         padding: 10px 14px !important;
@@ -448,6 +452,40 @@ body.banner-minimized .rt-nav-container {
     body.banner-closed .rt-nav-container,
     body:not(.banner-present) .rt-nav-container {
         top: 0 !important;
+    }
+}
+
+@media (max-width: 560px) {
+    .banner-icon {
+        display: none;
+    }
+}
+
+/* Narrowest screens: stack the CTA under the copy so the title gets the
+   full width instead of wrapping a word per line beside it. */
+@media (max-width: 480px) {
+    .workshop-banner {
+        flex-direction: column;
+        align-items: stretch !important;
+        gap: 10px;
+    }
+
+    .banner-actions {
+        align-self: stretch;
+    }
+
+    .banner-cta {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .workshop-banner.minimized .banner-actions {
+        display: none;
+    }
+
+    /* Stacked banner is taller than the 768px breakpoint assumes. */
+    body.banner-present .rt-nav-container {
+        top: 134px !important;
     }
 }
 
@@ -496,10 +534,10 @@ body.banner-minimized .rt-nav-container {
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Treasury Tech Virtual Forum: Product Demos Plus a Full Treasury Market Review</span>
+                    <span class="banner-highlight">Treasury Tech Virtual Forum</span>
                 </div>
                 <div class="banner-subtitle">
-                    September 22–24, 2026, from 9:00 AM ET — Register now to reserve your place.
+                    September 22–24, 2026 — product demos plus a full treasury market review.
                 </div>
             </div>
         </div>

--- a/header/main-menu/index.html
+++ b/header/main-menu/index.html
@@ -492,22 +492,20 @@ body.banner-minimized .rt-nav-container {
         <button class="close-btn" onclick="closeBanner(event)" aria-label="Close banner">&times;</button>
         
         <div class="banner-content">
-            <div class="banner-icon banner-speaker">
-                <img src="https://realtreasury.com/wp-content/uploads/2025/08/TraceyHeadshot-3.webp" alt="Tracey Knight, webinar presenter">
-            </div>
+            <div class="banner-icon">🖥️</div>
 
             <div class="banner-text">
                 <div class="banner-title">
-                    <span class="banner-highlight">Live Webinar: Is Your TMS on Life Support? Know When It's Time to Move On and How to Do It</span>
+                    <span class="banner-highlight">Treasury Tech Virtual Forum: Product Demos Plus a Full Treasury Market Review</span>
                 </div>
                 <div class="banner-subtitle">
-                    August 20, 2026, 2:00–2:30 PM ET — Register now to reserve your place.
+                    September 22–24, 2026, from 9:00 AM ET — Register now to reserve your place.
                 </div>
             </div>
         </div>
 
         <div class="banner-actions">
-            <a href="https://events.teams.microsoft.com/event/298a29ba-e836-40f1-851b-f1c35bc87aac@cdc422ca-d271-4ba3-856d-77081c6a7f04" class="banner-cta" onclick="registerLive(event)">
+            <a href="https://www.airmeet.com/e/b5614f90-335b-11f1-9b89-15a6c9df688e?Source=RealTreasury" class="banner-cta" onclick="registerLive(event)">
                 Register Now
                 <span>→</span>
             </a>
@@ -517,7 +515,7 @@ body.banner-minimized .rt-nav-container {
     <div class="site-content"></div>
 
 <script>
-const LIVE_WEBINAR_REGISTRATION_URL = 'https://events.teams.microsoft.com/event/298a29ba-e836-40f1-851b-f1c35bc87aac@cdc422ca-d271-4ba3-856d-77081c6a7f04';
+const LIVE_EVENT_REGISTRATION_URL = 'https://www.airmeet.com/e/b5614f90-335b-11f1-9b89-15a6c9df688e?Source=RealTreasury';
 
 // Add banner state management
 function updateBannerState() {
@@ -570,13 +568,13 @@ function expandBanner(event) {
         return;
     }
 
-    window.location.href = LIVE_WEBINAR_REGISTRATION_URL;
+    window.location.href = LIVE_EVENT_REGISTRATION_URL;
 }
 
 function registerLive(event) {
     event.preventDefault();
     event.stopPropagation();
-    window.location.href = LIVE_WEBINAR_REGISTRATION_URL;
+    window.location.href = LIVE_EVENT_REGISTRATION_URL;
 }
 
 function isMobileDevice() {


### PR DESCRIPTION
The August 20 TMS webinar in the site-wide banner has passed. This swaps it over to the **Treasury Tech Virtual Forum** and fits the copy to the banner's height budget.

## Content
- Title: **Treasury Tech Virtual Forum**
- Subtitle: September 22-24, 2026 - product demos plus a full treasury market review.
- Dates confirmed against the Airmeet event record (start `2026-09-22T13:00Z`, tz `America/New_York`)
- Register Now -> https://www.airmeet.com/e/b5614f90-335b-11f1-9b89-15a6c9df688e?Source=RealTreasury (verified 200)
- Dropped the speaker headshot back to the icon treatment earlier banners used; a three-day forum has no single presenter
- Renamed `LIVE_WEBINAR_REGISTRATION_URL` -> `LIVE_EVENT_REGISTRATION_URL`

## Why the CSS changes
The nav container is offset from the top by a hardcoded `80px` (desktop) / `112px` (mobile). Any title that wraps pushes the banner taller than that offset and the nav lands on top of it. So the title has to hold one line at every width.

Measured across eight viewport widths, `origin/main` vs this branch (banner height / title lines):

| width | origin/main | this branch |
|------:|------------:|------------:|
| 1440px | 81px / 1 line | 81px / 1 line |
| 1200px | 103px / 2 lines | 81px / 1 line |
| 1024px | 90px / 2 lines | 80px / 1 line |
| 900px | 90px / 2 lines | 88px / 1 line |
| 768px | 128px / 3 lines | 112px / 1 line |
| 600px | 149px / 4 lines | 112px / 1 line |
| 480px | 210px / 6 lines | 134px / 1 line |
| 375px | **411px / 13 lines** | 134px / 1 line |

Changes:
- Put the pitch in the subtitle, which wraps cheaply, and left the title as the event name alone
- Below 560px, hide the icon - it cost 60px the title column could not spare, forcing a word-per-line wrap
- Below 480px, stack the CTA under the copy (title gets full width) and give the nav a matching 134px offset
- Moved the 560/480 media blocks *after* the 768 block; source order meant the 768 rules were silently overriding them

Note the mobile overflow was pre-existing and worse before this change - the old webinar title wrapped to 13 lines at 375px. Fixing it was necessary to make the new title sit correctly.

**Not verified locally:** `.rt-nav-container` is injected by WordPress, not present in this snippet file, so the 134px offset is matched to the measured banner height but not confirmed against a live render. Worth a look on a phone after merge.

Branched off `origin/main`, so the three unpushed local guidebook commits are not carried along.

Generated with [Claude Code](https://claude.com/claude-code)